### PR TITLE
Translation from Haskell -> C data structures

### DIFF
--- a/csrc/zebra_data.c
+++ b/csrc/zebra_data.c
@@ -205,7 +205,7 @@ error_t add_row (
   , zebra_entity_t *entity
   , int32_t attribute_id
   , int64_t time
-  , int16_t priority
+  , int64_t priority
   , bool64_t tombstone
   , zebra_column_t **out_columns
   , int64_t *out_index )
@@ -226,7 +226,7 @@ error_t add_row (
     *out_index = count;
 
     int64_t *times = attribute->times;
-    int16_t *priorities = attribute->priorities;
+    int64_t *priorities = attribute->priorities;
     bool64_t *tombstones = attribute->tombstones;
 
     times[count] = time;

--- a/csrc/zebra_data.h
+++ b/csrc/zebra_data.h
@@ -50,7 +50,7 @@ struct zebra_column {
 
 typedef struct zebra_attribute {
     int64_t *times;
-    int16_t *priorities;
+    int64_t *priorities;
     bool64_t *tombstones;
     zebra_table_t table;
 } zebra_attribute_t;
@@ -75,11 +75,10 @@ error_t add_row (
   , zebra_entity_t *entity
   , int32_t attribute_id
   , int64_t time
-  , int16_t priority
+  , int64_t priority
   , bool64_t tombstone
   , zebra_column_t **out_columns
   , int64_t *out_index );
-
 
 error_t grow_column (
     anemone_mempool_t *pool

--- a/csrc/zebra_merge.c
+++ b/csrc/zebra_merge.c
@@ -102,8 +102,8 @@ error_t merge_attribute (anemone_mempool_t *pool, zebra_attribute_t *in1, zebra_
     while (in1_ix < in1->table.row_count && in2_ix < in2->table.row_count) {
         int64_t time1 = in1->times[in1_ix];
         int64_t time2 = in2->times[in2_ix];
-        int16_t prio1 = in1->priorities[in1_ix];
-        int16_t prio2 = in2->priorities[in2_ix];
+        int64_t prio1 = in1->priorities[in1_ix];
+        int64_t prio2 = in2->priorities[in2_ix];
 
         // ordered by time, priority. lowest priority first
         bool64_t copy_from_1 = (time1 < time2)

--- a/src/Zebra/Data.hs
+++ b/src/Zebra/Data.hs
@@ -4,6 +4,7 @@ module Zebra.Data (
   ) where
 
 import           Zebra.Data.Block as X
+import           Zebra.Data.Core as X
 import           Zebra.Data.Encoding as X
 import           Zebra.Data.Fact as X
 import           Zebra.Data.Schema as X

--- a/src/Zebra/Data/Block/Block.hs
+++ b/src/Zebra/Data/Block/Block.hs
@@ -26,8 +26,9 @@ import           X.Control.Monad.Trans.Either (EitherT, runEitherT, left)
 import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Unboxed as Unboxed
 
-import           Zebra.Data.Block.Index
 import           Zebra.Data.Block.Entity
+import           Zebra.Data.Block.Index
+import           Zebra.Data.Core
 import           Zebra.Data.Encoding
 import           Zebra.Data.Fact
 import           Zebra.Data.Table

--- a/src/Zebra/Data/Block/Entity.hs
+++ b/src/Zebra/Data/Block/Entity.hs
@@ -22,6 +22,7 @@ import           P
 import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Unboxed as Unboxed
 
+import           Zebra.Data.Core
 import           Zebra.Data.Fact
 
 

--- a/src/Zebra/Data/Core.hs
+++ b/src/Zebra/Data/Core.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+module Zebra.Data.Core (
+    EntityId(..)
+  , EntityHash(..)
+  , AttributeId(..)
+  , AttributeName(..)
+
+  , Time(..)
+  , Priority(..)
+  , Tombstone(..)
+
+  , hashEntityId
+  , fromDay
+  , toDay
+  , int64OfTombstone
+  , tombstoneOfInt64
+  ) where
+
+import           Anemone.Foreign.Hash (fasthash32)
+
+import           Control.Lens ((^.), re)
+
+import           Data.AffineSpace ((.-.), (.+^))
+import           Data.ByteString (ByteString)
+import           Data.Thyme.Calendar (Day, YearMonthDay(..), gregorian)
+import           Data.Typeable (Typeable)
+import           Data.Vector.Unboxed.Deriving (derivingUnbox)
+import           Data.Word (Word32)
+
+import           Foreign.Ptr (castPtr)
+import           Foreign.Storable (Storable(..))
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+
+newtype EntityId =
+  EntityId {
+      unEntityId :: ByteString
+    } deriving (Eq, Ord, Generic, Typeable)
+
+newtype EntityHash =
+  EntityHash {
+      unEntityHash :: Word32
+    } deriving (Eq, Ord, Generic, Typeable)
+
+newtype AttributeId =
+  AttributeId {
+      unAttributeId :: Int
+    } deriving (Eq, Ord, Generic, Typeable)
+
+newtype AttributeName =
+  AttributeName {
+      unAttributeName :: Text
+    } deriving (Eq, Ord, Generic, Typeable)
+
+newtype Time =
+  Time {
+      unTime :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Typeable, Storable)
+
+newtype Priority =
+  Priority {
+      unPriority :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Typeable, Storable)
+
+data Tombstone =
+    NotTombstone
+  | Tombstone
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+instance Storable Tombstone where
+  sizeOf _ =
+    sizeOf (0 :: Int64)
+
+  alignment _ =
+    alignment (0 :: Int64)
+
+  peekElemOff p i =
+    fmap tombstoneOfInt64 $
+    peekElemOff (castPtr p) i
+
+  pokeElemOff p i x =
+    pokeElemOff (castPtr p) i $
+    int64OfTombstone x
+
+instance Show EntityId where
+  showsPrec =
+    gshowsPrec
+
+instance Show EntityHash where
+  showsPrec =
+    gshowsPrec
+
+instance Show AttributeId where
+  showsPrec =
+    gshowsPrec
+
+instance Show AttributeName where
+  showsPrec =
+    gshowsPrec
+
+instance Show Time where
+  showsPrec =
+    gshowsPrec
+
+instance Show Priority where
+  showsPrec =
+    gshowsPrec
+
+hashEntityId :: EntityId -> EntityHash
+hashEntityId =
+  EntityHash . fasthash32 . unEntityId
+{-# INLINE hashEntityId #-}
+
+fromDay :: Day -> Time
+fromDay day =
+  Time . fromIntegral $ (day .-. ivoryEpoch) * 86400
+{-# INLINE fromDay #-}
+
+toDay :: Time -> Day
+toDay (Time time) =
+  ivoryEpoch .+^ fromIntegral time `div` 86400
+{-# INLINE toDay #-}
+
+ivoryEpoch :: Day
+ivoryEpoch =
+  YearMonthDay 1600 3 1 ^. re gregorian
+{-# INLINE ivoryEpoch #-}
+
+int64OfTombstone :: Tombstone -> Int64
+int64OfTombstone = \case
+  NotTombstone ->
+    0
+  Tombstone ->
+    1
+{-# INLINE int64OfTombstone #-}
+
+tombstoneOfInt64 :: Int64 -> Tombstone
+tombstoneOfInt64 w =
+  case w of
+    0 ->
+      NotTombstone
+    _ ->
+      Tombstone
+{-# INLINE tombstoneOfInt64 #-}
+
+derivingUnbox "EntityHash"
+  [t| EntityHash -> Word32 |]
+  [| unEntityHash |]
+  [| EntityHash |]
+
+derivingUnbox "AttributeId"
+  [t| AttributeId -> Int |]
+  [| unAttributeId |]
+  [| AttributeId |]
+
+derivingUnbox "Time"
+  [t| Time -> Int64 |]
+  [| unTime |]
+  [| Time |]
+
+derivingUnbox "Priority"
+  [t| Priority -> Int64 |]
+  [| unPriority |]
+  [| Priority |]
+
+derivingUnbox "Tombstone"
+  [t| Tombstone -> Int64 |]
+  [| int64OfTombstone |]
+  [| tombstoneOfInt64 |]

--- a/src/Zebra/Data/Entity.hs
+++ b/src/Zebra/Data/Entity.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Zebra.Data.Entity where
+
+import           Data.Typeable (Typeable)
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+import           Zebra.Data.Core
+import           Zebra.Data.Table
+
+
+data Attribute =
+  Attribute {
+      attributeTime :: !(Storable.Vector Time)
+    , attributePriority :: !(Storable.Vector Priority)
+    , attributeTombstone :: !(Storable.Vector Tombstone)
+    , attributeTable :: !Table
+    } deriving (Eq, Ord, Generic, Typeable)
+
+data Entity =
+  Entity {
+      entityHash :: !EntityHash
+    , entityId :: !EntityId
+    , entityAttributes :: !(Boxed.Vector Attribute)
+    } deriving (Eq, Ord, Generic, Typeable)
+
+instance Show Attribute where
+  showsPrec =
+    gshowsPrec
+
+instance Show Entity where
+  showsPrec =
+    gshowsPrec

--- a/src/Zebra/Data/Fact.hs
+++ b/src/Zebra/Data/Fact.hs
@@ -1,41 +1,19 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
 module Zebra.Data.Fact (
     Fact(..)
   , Value(..)
-  , EntityId(..)
-  , EntityHash(..)
-  , AttributeId(..)
-  , AttributeName(..)
-  , Time(..)
-  , Priority(..)
-
-  , hashEntityId
-  , fromDay
-  , toDay
   ) where
 
-import           Control.Lens ((^.), re)
-
-import           Data.AffineSpace ((.-.), (.+^))
-import           Data.ByteString (ByteString)
-import           Data.Hashable (hash)
-import           Data.Thyme.Calendar (Day, YearMonthDay(..), gregorian)
+import           Data.Thyme.Calendar (Day)
 import           Data.Typeable (Typeable)
 import qualified Data.Vector as Boxed
-import           Data.Vector.Unboxed.Deriving (derivingUnbox)
-import           Data.Word (Word32)
 
 import           GHC.Generics (Generic)
 
 import           P
 
-import           X.Text.Show (gshowsPrec)
+import           Zebra.Data.Core
 
 
 data Fact =
@@ -57,93 +35,3 @@ data Value =
   | ListValue !(Boxed.Vector Value)
   | StructValue !(Boxed.Vector (Maybe' Value))
     deriving (Eq, Ord, Show, Generic, Typeable)
-
-newtype EntityId =
-  EntityId {
-      unEntityId :: ByteString
-    } deriving (Eq, Ord, Generic, Typeable)
-
-newtype EntityHash =
-  EntityHash {
-      unEntityHash :: Word32
-    } deriving (Eq, Ord, Generic, Typeable)
-
-newtype AttributeId =
-  AttributeId {
-      unAttributeId :: Int
-    } deriving (Eq, Ord, Generic, Typeable)
-
-newtype AttributeName =
-  AttributeName {
-      unAttributeName :: Text
-    } deriving (Eq, Ord, Generic, Typeable)
-
-newtype Time =
-  Time {
-      unTime :: Int64
-    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Typeable)
-
-newtype Priority =
-  Priority {
-      unPriority :: Int
-    } deriving (Eq, Ord, Generic, Typeable)
-
-instance Show EntityId where
-  showsPrec =
-    gshowsPrec
-
-instance Show EntityHash where
-  showsPrec =
-    gshowsPrec
-
-instance Show AttributeId where
-  showsPrec =
-    gshowsPrec
-
-instance Show AttributeName where
-  showsPrec =
-    gshowsPrec
-
-instance Show Time where
-  showsPrec =
-    gshowsPrec
-
-instance Show Priority where
-  showsPrec =
-    gshowsPrec
-
-hashEntityId :: EntityId -> EntityHash
-hashEntityId =
-  EntityHash . fromIntegral . hash . unEntityId
-
-fromDay :: Day -> Time
-fromDay day =
-  Time . fromIntegral $ (day .-. ivoryEpoch) * 86400
-
-toDay :: Time -> Day
-toDay (Time time) =
-  ivoryEpoch .+^ fromIntegral time `div` 86400
-
-ivoryEpoch :: Day
-ivoryEpoch =
-  YearMonthDay 1600 3 1 ^. re gregorian
-
-derivingUnbox "EntityHash"
-  [t| EntityHash -> Word32 |]
-  [| unEntityHash |]
-  [| EntityHash |]
-
-derivingUnbox "AttributeId"
-  [t| AttributeId -> Int |]
-  [| unAttributeId |]
-  [| AttributeId |]
-
-derivingUnbox "Time"
-  [t| Time -> Int64 |]
-  [| unTime |]
-  [| Time |]
-
-derivingUnbox "Priority"
-  [t| Priority -> Int |]
-  [| unPriority |]
-  [| Priority |]

--- a/src/Zebra/Data/Schema.hs
+++ b/src/Zebra/Data/Schema.hs
@@ -34,8 +34,8 @@ import           P
 
 import           X.Text.Show (gshowsPrec)
 
+import           Zebra.Data.Core
 import           Zebra.Data.Encoding
-import           Zebra.Data.Fact
 
 
 newtype Schema =

--- a/src/Zebra/Data/Table.hs
+++ b/src/Zebra/Data/Table.hs
@@ -50,6 +50,7 @@ import qualified X.Data.Vector.Generic as Generic
 import qualified X.Data.Vector.Storable as Storable
 import           X.Text.Show (gshowsPrec)
 
+import           Zebra.Data.Core
 import           Zebra.Data.Encoding
 import           Zebra.Data.Fact
 import           Zebra.Data.Schema

--- a/src/Zebra/Data/Table/Mutable.hs
+++ b/src/Zebra/Data/Table/Mutable.hs
@@ -51,6 +51,7 @@ import           X.Control.Monad.Trans.Either (EitherT, runEitherT, left)
 import           X.Data.Vector.Grow (Grow)
 import qualified X.Data.Vector.Grow as Grow
 
+import           Zebra.Data.Core
 import           Zebra.Data.Encoding
 import           Zebra.Data.Fact
 import           Zebra.Data.Table (Table(..), Column(..))

--- a/src/Zebra/Foreign/Bindings.hsc
+++ b/src/Zebra/Foreign/Bindings.hsc
@@ -2,9 +2,15 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
-module Zebra.Foreign where
+module Zebra.Foreign.Bindings where
 
 import Anemone.Foreign.Data (CError(..))
+
+--
+-- This module contains 1:1 bindings for all the zebra header files, in the
+-- style of bindings-DSL, for "nice" wrappers, see the other Zebra.Foreign.*
+-- modules.
+--
 
 #include <bindings.dsl.h>
 #include "zebra_bindings.h"
@@ -40,7 +46,7 @@ import Anemone.Foreign.Data (CError(..))
 
 #starttype struct zebra_attribute
 #field times , Ptr Int64
-#field priorities , Ptr Int16
+#field priorities , Ptr Int64
 #field tombstones , Ptr Int64
 #field table , <zebra_table>
 #stoptype

--- a/src/Zebra/Foreign/Entity.hs
+++ b/src/Zebra/Foreign/Entity.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Zebra.Foreign.Entity (
+    ForeignEntity(..)
+  , foreignOfEntity
+  ) where
+
+import           Anemone.Foreign.Mempool
+
+import qualified Data.ByteString as B
+import           Data.ByteString.Internal (ByteString(..))
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
+import           Data.Word (Word8)
+
+import           Foreign.ForeignPtr
+import           Foreign.Marshal.Utils
+import           Foreign.Ptr
+import           Foreign.Storable
+
+import           P
+
+import qualified Prelude as Savage
+
+import           System.IO
+
+import           Zebra.Data.Core
+import           Zebra.Data.Entity
+import           Zebra.Data.Table
+
+import           Zebra.Foreign.Bindings
+
+newtype ForeignEntity =
+  ForeignEntity {
+      unForeignEntity :: Ptr C'zebra_entity
+    }
+
+foreignOfEntity :: Mempool -> Entity -> IO ForeignEntity
+foreignOfEntity pool entity = do
+  c_entity <- alloc pool
+  pokeEntity pool c_entity entity
+  pure $ ForeignEntity c_entity
+
+pokeEntity :: Mempool -> Ptr C'zebra_entity -> Entity -> IO ()
+pokeEntity pool c_entity (Entity hash eid attributes) = do
+  let
+    n_attrs =
+      Boxed.length attributes
+
+    eid_len =
+      B.length $ unEntityId eid
+
+  c_attributes <- calloc pool $ fromIntegral n_attrs
+
+  poke (p'zebra_entity'hash c_entity) $ unEntityHash hash
+  poke (p'zebra_entity'id_length c_entity) $ fromIntegral eid_len
+  pokeByteString pool (p'zebra_entity'id_bytes c_entity) $ unEntityId eid
+  poke (p'zebra_entity'attribute_count c_entity) $ fromIntegral n_attrs
+  poke (p'zebra_entity'attributes c_entity) c_attributes
+
+  flip Boxed.imapM_ attributes $ \i attribute ->
+    let
+      ptr =
+        c_attributes `plusPtr`
+        (i * sizeOf (Savage.undefined :: C'zebra_attribute))
+    in
+      pokeAttribute pool ptr attribute
+
+pokeAttribute :: Mempool -> Ptr C'zebra_attribute -> Attribute -> IO ()
+pokeAttribute pool c_attribute (Attribute times priorities tombstones table) = do
+  -- NOTE: These casts depend on the Storable instance for
+  -- NOTE: time/priority/tombstone being a single peek/poke
+  -- NOTE: of an Int64, which they should be.
+  pokeVector pool (castPtr $ p'zebra_attribute'times c_attribute) times
+  pokeVector pool (castPtr $ p'zebra_attribute'priorities c_attribute) priorities
+  pokeVector pool (castPtr $ p'zebra_attribute'tombstones c_attribute) tombstones
+  pokeTable pool (p'zebra_attribute'table c_attribute) table
+
+pokeTable :: Mempool -> Ptr C'zebra_table -> Table -> IO ()
+pokeTable pool c_table table@(Table columns) = do
+  let
+    n_rows =
+      rowsOfTable table
+
+    n_cols =
+      Boxed.length columns
+
+  c_columns <- calloc pool $ fromIntegral n_cols
+
+  poke (p'zebra_table'row_count c_table) $ fromIntegral n_rows
+  poke (p'zebra_table'row_capacity c_table) $ fromIntegral n_rows
+  poke (p'zebra_table'column_count c_table) $ fromIntegral n_cols
+  poke (p'zebra_table'columns c_table) c_columns
+
+  flip Boxed.imapM_ columns $ \i column ->
+    let
+      ptr =
+        c_columns `plusPtr`
+        (i * sizeOf (Savage.undefined :: C'zebra_column))
+    in
+      pokeColumn pool ptr column
+
+pokeColumn :: Mempool -> Ptr C'zebra_column -> Column -> IO ()
+pokeColumn pool c_column = \case
+  ByteColumn bs -> do
+    poke (p'zebra_column'type c_column) C'ZEBRA_BYTE
+    pokeByteString pool (p'zebra_data'b $ p'zebra_column'data c_column) bs
+
+  IntColumn xs -> do
+    poke (p'zebra_column'type c_column) C'ZEBRA_INT
+    pokeVector pool (p'zebra_data'i $ p'zebra_column'data c_column) xs
+
+  DoubleColumn xs -> do
+    poke (p'zebra_column'type c_column) C'ZEBRA_DOUBLE
+    pokeVector pool (p'zebra_data'd $ p'zebra_column'data c_column) xs
+
+  ArrayColumn ns table -> do
+    poke (p'zebra_column'type c_column) C'ZEBRA_ARRAY
+    pokeVector pool (p'zebra_data'a'n $ p'zebra_column'data c_column) ns
+    pokeTable pool (p'zebra_data'a'table $ p'zebra_column'data c_column) table
+
+pokeByteString :: Mempool -> Ptr (Ptr Word8) -> ByteString -> IO ()
+pokeByteString pool dst (PS fp off len) =
+  poke dst =<< allocCopy pool fp off len
+
+pokeVector :: Storable a => Mempool -> Ptr (Ptr a) -> Storable.Vector a -> IO ()
+pokeVector pool dst xs =
+  let
+    (fp, off, len) =
+      Storable.unsafeToForeignPtr xs
+  in
+    poke dst =<< allocCopy pool fp off len
+
+allocCopy :: Mempool -> ForeignPtr a -> Int -> Int -> IO (Ptr a)
+allocCopy pool fp off len =
+  withForeignPtr fp $ \src -> do
+    dst <- allocBytes pool (fromIntegral len)
+    copyBytes dst (src `plusPtr` off) len
+    pure dst

--- a/src/Zebra/Serial/Block.hs
+++ b/src/Zebra/Serial/Block.hs
@@ -39,9 +39,9 @@ import qualified X.Data.Vector.Generic as Generic
 import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data.Block
-import           Zebra.Data.Fact
-import           Zebra.Data.Table
+import           Zebra.Data.Core
 import           Zebra.Data.Schema
+import           Zebra.Data.Table
 import           Zebra.Serial.Array
 
 
@@ -206,15 +206,15 @@ bIndices xs =
 
     times =
       Unboxed.convert $
-      Unboxed.map (fromIntegral . unTime . indexTime) xs
+      Unboxed.map (unTime . indexTime) xs
 
     priorities =
       Unboxed.convert $
-      Unboxed.map (fromIntegral . unPriority . indexPriority) xs
+      Unboxed.map (unPriority . indexPriority) xs
 
     tombstones =
       Unboxed.convert $
-      Unboxed.map (fromIntegral . wordOfTombstone . indexTombstone) xs
+      Unboxed.map (int64OfTombstone . indexTombstone) xs
   in
     Build.word32LE icount <>
     bIntArray times <>
@@ -230,15 +230,15 @@ getIndices = do
 
   let
     times =
-      Unboxed.map (Time . fromIntegral) $
+      Unboxed.map Time $
       Unboxed.convert itimes
 
     priorities =
-      Unboxed.map (Priority . fromIntegral) $
+      Unboxed.map Priority $
       Unboxed.convert ipriorities
 
     tombstones =
-      Unboxed.map (tombstoneOfWord . fromIntegral) $
+      Unboxed.map tombstoneOfInt64 $
       Unboxed.convert itombstones
 
   pure $ Unboxed.zipWith3 BlockIndex times priorities tombstones

--- a/src/Zebra/Serial/Header.hs
+++ b/src/Zebra/Serial/Header.hs
@@ -25,7 +25,7 @@ import qualified Data.Vector as Boxed
 
 import           P
 
-import           Zebra.Data.Fact
+import           Zebra.Data.Core
 import           Zebra.Data.Schema
 import           Zebra.Serial.Array
 

--- a/test/Test/Zebra/Data/Block.hs
+++ b/test/Test/Zebra/Data/Block.hs
@@ -16,7 +16,7 @@ import           Test.Zebra.Jack
 import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Data.Block
-import           Zebra.Data.Fact
+import           Zebra.Data.Core
 import           Zebra.Data.Table.Mutable
 
 

--- a/test/Test/Zebra/Data/Core.hs
+++ b/test/Test/Zebra/Data/Core.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Zebra.Data.Fact where
+module Test.Zebra.Data.Core where
 
 import           Disorder.Jack (Property, quickCheckAll)
 import           Disorder.Jack (gamble, tripping)
@@ -11,7 +11,7 @@ import           System.IO (IO)
 
 import           Test.Zebra.Jack
 
-import           Zebra.Data.Fact
+import           Zebra.Data.Core
 
 
 prop_roundtrip_day :: Property

--- a/test/Test/Zebra/Jack.hs
+++ b/test/Test/Zebra/Jack.hs
@@ -46,7 +46,7 @@ import qualified Data.Vector.Unboxed as Unboxed
 
 import           Disorder.Corpus (muppets, southpark, boats)
 import           Disorder.Jack (Jack, mkJack, shrinkTowards, sized)
-import           Disorder.Jack (elements, arbitrary, chooseInt, sizedBounded)
+import           Disorder.Jack (elements, arbitrary, choose, chooseInt, sizedBounded)
 import           Disorder.Jack (oneOf, oneOfRec, listOf, listOfN, justOf, maybeOf)
 
 import           P
@@ -57,6 +57,7 @@ import           Test.QuickCheck.Instances ()
 import           Text.Printf (printf)
 
 import           Zebra.Data.Block
+import           Zebra.Data.Core
 import           Zebra.Data.Encoding
 import           Zebra.Data.Fact
 import           Zebra.Data.Schema
@@ -171,7 +172,7 @@ jYear =
 
 jPriority :: Jack Priority
 jPriority =
-  Priority <$> chooseInt (0, 100000)
+  Priority <$> choose (0, 100000)
 
 jBlock :: Jack Block
 jBlock =

--- a/test/Test/Zebra/Serial/Block.hs
+++ b/test/Test/Zebra/Serial/Block.hs
@@ -20,7 +20,7 @@ import           Test.Zebra.Util
 import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Data.Block
-import           Zebra.Data.Fact
+import           Zebra.Data.Core
 import           Zebra.Data.Schema
 import           Zebra.Data.Table
 import           Zebra.Serial.Block

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,7 +1,7 @@
 import           Disorder.Core.Main
 
 import qualified Test.Zebra.Data.Block
-import qualified Test.Zebra.Data.Fact
+import qualified Test.Zebra.Data.Core
 import qualified Test.Zebra.Data.Schema
 import qualified Test.Zebra.Data.Table
 import qualified Test.Zebra.Data.Table.Mutable
@@ -15,7 +15,7 @@ main :: IO ()
 main =
   disorderMain [
       Test.Zebra.Data.Block.tests
-    , Test.Zebra.Data.Fact.tests
+    , Test.Zebra.Data.Core.tests
     , Test.Zebra.Data.Schema.tests
     , Test.Zebra.Data.Table.tests
     , Test.Zebra.Data.Table.Mutable.tests

--- a/zebra.cabal
+++ b/zebra.cabal
@@ -25,7 +25,6 @@ library
                     , bindings-DSL                    >= 1.0.0      && <= 1.0.23
                     , bytestring                      == 0.10.*
                     , containers                      == 0.5.*
-                    , hashable                        == 1.2.*
                     , lens                            >= 4.7        && < 4.15
                     , mtl                             == 2.2.*
                     , pretty-show                     == 1.6.*
@@ -45,25 +44,31 @@ library
 
   exposed-modules:
                     Zebra
+
                     Zebra.Data
                     Zebra.Data.Block
                     Zebra.Data.Block.Block
                     Zebra.Data.Block.Entity
                     Zebra.Data.Block.Index
+                    Zebra.Data.Core
                     Zebra.Data.Encoding
                     Zebra.Data.Fact
+                    Zebra.Data.Schema
                     Zebra.Data.Table
                     Zebra.Data.Table.Mutable
-                    Zebra.Data.Schema
-                    Zebra.Foreign
+
+                    Zebra.Foreign.Bindings
+                    Zebra.Foreign.Entity
+
                     Zebra.Merge.Base
                     Zebra.Merge.Block
                     Zebra.Merge.Entity
+
                     Zebra.Serial
                     Zebra.Serial.Array
                     Zebra.Serial.Block
-                    Zebra.Serial.Header
                     Zebra.Serial.File
+                    Zebra.Serial.Header
 
   include-dirs:
                        csrc


### PR DESCRIPTION
This is the beginning of the two way translation between Haskell and C data structures.

Roundtrip tests will come in the next PR when I can go from C -> Haskell.

!! @amosr @tranma

This also includes a few minor changes/fixups:
- We're now using the hash from `anemone` instead of `hashable` so that it if `hashable` changes all of our files won't be become corrupt. The hash in our files can now be well defined in our spec.
- I changed the zebra priority to be 64-bit for consistency with all the other arrays of numbers/booleans
- There is now a `Zebra.Data.Core` module which has some of the stuff (e.g. `EntityId`, `Tombstone`) that used to be in `Zebra.Data.Fact` and `Zebra.Data.Block.Index`
