### PR TITLE
Some cleanup

### DIFF
--- a/csrc/zebra_data.h
+++ b/csrc/zebra_data.h
@@ -69,12 +69,13 @@ typedef struct zebra_block_entity {
     int64_t id_length;
     uint8_t *id_bytes;
 
-    int64_t attribute_count;
+    /* length = attribute_count from parent zebra_block */
     int64_t *attribute_ids;
     int64_t *attribute_row_counts;
 } zebra_block_entity_t;
 
 typedef struct zebra_block {
+    int64_t attribute_count;
     int64_t entity_count;
     zebra_block_entity_t *entities;
 
@@ -83,17 +84,18 @@ typedef struct zebra_block {
     int64_t *priorities;
     bool64_t *tombstones;
 
-    int64_t table_count;
+    /* length = attribute_count */
     zebra_table_t *tables;
 } zebra_block_t;
 
-error_t alloc_table (
+error_t zebra_alloc_table (
     anemone_mempool_t *pool
   , zebra_table_t *table
   , const uint8_t **pp_schema
-  , const uint8_t *pe_schema );
+  , const uint8_t *pe_schema
+  );
 
-error_t add_row (
+error_t zebra_add_row (
     anemone_mempool_t *pool
   , zebra_entity_t *entity
   , int32_t attribute_id
@@ -101,20 +103,24 @@ error_t add_row (
   , int64_t priority
   , bool64_t tombstone
   , zebra_column_t **out_columns
-  , int64_t *out_index );
+  , int64_t *out_index
+  );
 
-error_t grow_column (
+error_t zebra_grow_column (
     anemone_mempool_t *pool
   , zebra_column_t *column
   , int64_t old_capacity
-  , int64_t new_capacity );
+  , int64_t new_capacity
+  );
 
-error_t grow_table (
+error_t zebra_grow_table (
     anemone_mempool_t *pool
-  , zebra_table_t *table );
+  , zebra_table_t *table
+  );
 
-error_t grow_attribute (
+error_t zebra_grow_attribute (
     anemone_mempool_t *pool
-  , zebra_attribute_t *attribute );
+  , zebra_attribute_t *attribute
+  );
 
 #endif//__ZEBRA_DATA_H

--- a/csrc/zebra_merge.c
+++ b/csrc/zebra_merge.c
@@ -41,7 +41,7 @@ error_t merge_append_column (anemone_mempool_t *pool, zebra_column_t *in, int64_
                 // merge_append_* should copy multiple values & grow once at start.
                 for (int64_t v = 0; v < value_count; ++v) {
                     out->data.a.table.row_count++;
-                    grow_table (pool, &out->data.a.table);
+                    zebra_grow_table (pool, &out->data.a.table);
 
                     err = merge_append_table (pool, &in->data.a.table, value_in_ix, &out->data.a.table, value_out_ix);
                     if (err) return err;
@@ -75,7 +75,7 @@ error_t merge_append_attribute (anemone_mempool_t *pool, zebra_attribute_t *in, 
     int64_t out_ix = out->table.row_count;
 
     out->table.row_count++;
-    err = grow_attribute (pool, out);
+    err = zebra_grow_attribute (pool, out);
     if (err) return err;
 
     out->times[out_ix] = in->times[ix];

--- a/src/Zebra/Data/Table.hs
+++ b/src/Zebra/Data/Table.hs
@@ -26,8 +26,8 @@ module Zebra.Data.Table (
   , concatColumns
   , appendTables
   , appendColumns
-  , splitAtTables
-  , splitAtColumns
+  , splitAtTable
+  , splitAtColumn
   ) where
 
 import           Control.Monad.State.Strict (MonadState(..))
@@ -407,13 +407,13 @@ appendColumns x y =
     (_, _) ->
       Left $ TableAppendColumnsMismatch x y
 
-splitAtTables :: Int -> Table -> (Table, Table)
-splitAtTables i (Table fs) =
-  let (as,bs) = Boxed.unzip $ Boxed.map (splitAtColumns i) fs
+splitAtTable :: Int -> Table -> (Table, Table)
+splitAtTable i (Table fs) =
+  let (as,bs) = Boxed.unzip $ Boxed.map (splitAtColumn i) fs
   in  (Table as, Table bs)
 
-splitAtColumns :: Int -> Column -> (Column, Column)
-splitAtColumns i =
+splitAtColumn :: Int -> Column -> (Column, Column)
+splitAtColumn i =
   \case
     ByteColumn vs
      -> bye ByteColumn $ B.splitAt i vs
@@ -424,7 +424,7 @@ splitAtColumns i =
     ArrayColumn len rec
      -> let (len1, len2) = Storable.splitAt i len
             nested_count = fromIntegral $ Storable.sum len1
-            (rec1, rec2) = splitAtTables nested_count rec
+            (rec1, rec2) = splitAtTable nested_count rec
         in  (ArrayColumn len1 rec1, ArrayColumn len2 rec2)
   where
    bye f = bimap f f

--- a/src/Zebra/Foreign/Bindings.hsc
+++ b/src/Zebra/Foreign/Bindings.hsc
@@ -63,21 +63,17 @@ import Anemone.Foreign.Data (CError(..))
 #field hash , Word32
 #field id_length , Int64
 #field id_bytes , Ptr Word8
-#field attribute_count , Int64
 #field attribute_ids , Ptr Int64
 #field attribute_row_counts , Ptr Int64
 #stoptype
 
 #starttype struct zebra_block
+#field attribute_count , Int64
 #field entity_count , Int64
 #field entities , Ptr <zebra_block_entity>
 #field row_count , Int64
 #field times , Ptr Int64
 #field priorities , Ptr Int64
 #field tombstones , Ptr Int64
-#field table_count , Int64
 #field tables , Ptr <zebra_table>
 #stoptype
-
-#ccall alloc_table , Ptr <zebra_table> -> Ptr (Ptr Word8) -> Ptr Word8 -> IO CError
-#ccall add_row , Ptr <zebra_entity> -> Int32 -> Int64 -> Int16 -> Int64 -> Ptr (Ptr <zebra_column>) -> Ptr Int64 -> IO CError

--- a/src/Zebra/Foreign/Table.hs
+++ b/src/Zebra/Foreign/Table.hs
@@ -73,7 +73,7 @@ peekColumn n_rows c_column = do
         <*> peekTable (p'zebra_data'a'table $ p'zebra_column'data c_column)
 
     _ ->
-      left $ UnknownColumnType typ
+      left $ ForeignUnknownColumnType typ
 
 pokeColumn :: MonadIO m => Mempool -> Ptr C'zebra_column -> Column -> m ()
 pokeColumn pool c_column = \case

--- a/src/Zebra/Foreign/Util.hs
+++ b/src/Zebra/Foreign/Util.hs
@@ -36,7 +36,8 @@ import qualified Prelude as Savage
 
 
 data ForeignError =
-    UnknownColumnType !CUInt
+    ForeignUnknownColumnType !CUInt
+  | ForeignInvalidAttributeCount !Int !Int
     deriving (Eq, Ord, Show)
 
 allocCopy :: MonadIO m => Mempool -> ForeignPtr a -> Int -> Int -> m (Ptr a)

--- a/src/Zebra/Merge/Entity.hs
+++ b/src/Zebra/Merge/Entity.hs
@@ -41,7 +41,7 @@ entitiesOfBlock blockId (Block entities indices tables) =
            dense_attrs       = denseAttributeCount rx attrs
            ix_attrs          = Generic.unsafeSplits id ix_here dense_attrs
            dense_counts      = Boxed.map Unboxed.length ix_attrs
-           (rx_here,rx_rest) = Boxed.unzip $ Boxed.zipWith splitAtTables dense_counts rx
+           (rx_here,rx_rest) = Boxed.unzip $ Boxed.zipWith splitAtTable dense_counts rx
 
            acc'              = (ix_rest, rx_rest)
            ix_blockId        = Boxed.map (Unboxed.map (,blockId)) ix_attrs
@@ -116,7 +116,7 @@ mergeEntityTable aid aixs tables = do
     init =
       case Map.minView tables of
         Just (r,_) ->
-          return $ fst $ splitAtTables 0 r
+          return $ fst $ splitAtTable 0 r
         Nothing ->
           Left $ MergeAttributeWithoutTable aid
 
@@ -128,7 +128,7 @@ mergeEntityTable aid aixs tables = do
     splitLookup blockid recs =
       case Map.lookup blockid recs of
         Just r -> do
-          let (this,that) = splitAtTables 1 r
+          let (this,that) = splitAtTable 1 r
           return (this, Map.insert blockid that recs)
         Nothing ->
           Left $ MergeBlockDataWithoutTable aid blockid

--- a/test/Test/Zebra/Data/Table.hs
+++ b/test/Test/Zebra/Data/Table.hs
@@ -18,7 +18,7 @@ prop_roundtrip_splitAt :: Property
 prop_roundtrip_splitAt =
   gamble arbitrary $ \ix ->
   gamble jTable $
-    tripping (splitAtTables ix) (uncurry appendTables)
+    tripping (splitAtTable ix) (uncurry appendTables)
 
 return []
 tests :: IO Bool

--- a/test/Test/Zebra/Foreign/Entity.hs
+++ b/test/Test/Zebra/Foreign/Entity.hs
@@ -24,7 +24,7 @@ prop_roundtrip_entities :: Property
 prop_roundtrip_entities =
   gamble jEntity $ \entity ->
   testIO . bracket Mempool.create Mempool.free $ \pool ->
-    trippingIO (foreignOfEntity pool) entityOfForeign entity
+    trippingIO (liftE . foreignOfEntity pool) entityOfForeign entity
 
 return []
 tests :: IO Bool

--- a/test/Test/Zebra/Serial/Block.hs
+++ b/test/Test/Zebra/Serial/Block.hs
@@ -6,7 +6,7 @@ import qualified Data.Vector as Boxed
 import qualified Data.Vector.Unboxed as Unboxed
 
 import           Disorder.Jack (Property)
-import           Disorder.Jack (quickCheckAll, gamble, listOf, counterexample)
+import           Disorder.Jack (quickCheckAll, gamble, listOf, choose, counterexample)
 
 import           P
 
@@ -52,7 +52,8 @@ prop_roundtrip_block =
 
 prop_roundtrip_entities :: Property
 prop_roundtrip_entities =
-  gamble (Boxed.fromList <$> listOf jBlockEntity) $
+  gamble (choose (0, 10)) $ \n ->
+  gamble (Boxed.fromList <$> listOf (jBlockEntity n)) $
     trippingSerial bEntities getEntities
 
 prop_roundtrip_attributes :: Property

--- a/zebra.cabal
+++ b/zebra.cabal
@@ -147,6 +147,7 @@ test-suite test
                     , quickcheck-instances            == 0.3.*
                     , text                            == 1.2.*
                     , thyme                           == 0.3.*
+                    , transformers                    == 0.5.*
                     , vector                          >= 0.10       && < 0.12
 
 test-suite test-io


### PR DESCRIPTION
! @amosr @tranma 
- Putting `zebra_` prefixes on exported functions
- Rename `splitAtTables` -> `splitAtTable` (as it only takes 1)
- Remove `attribute_count` from each `zebra_block_entity` as it should be implied by the parent (these could get out of sync before)
