### PR TITLE
Show attribute id when catting

### DIFF
--- a/main/zebra.hs
+++ b/main/zebra.hs
@@ -282,9 +282,10 @@ catEntity opts entity = lift $ do
 catEntityFacts :: Entity.Entity -> IO ()
 catEntityFacts entity = do
   IO.putStrLn ("      Values:")
-  let facts' = Boxed.filter ((>0) . Storable.length . Entity.attributeTime)
+  let facts' = Boxed.filter ((>0) . Storable.length . Entity.attributeTime . snd)
+             $ Boxed.indexed
              $ Entity.entityAttributes entity
-  mapM_ (putIndented 8 . ppShow) facts'
+  mapM_ (\(ix,attr) -> putIndented 8 (show ix <> ": " <> ppShow attr)) facts'
 
 putIndented :: Int -> String -> IO ()
 putIndented indents str =


### PR DESCRIPTION
`zebra cat` filters out the empty attributes, but wasn't displaying the attribute id - so you didn't really know which values it was printing. I still would prefer a different pretty than `ppShow` but it at least works now

```
Block 0
    EntityId "SAVAGE+797B794D2039EDE3034243596FE3084A" (EntityHash 3289000)
      Values:
        0: Attribute
          [ Time 13132972800 ]
          [ Priority 7 ]
          [ NotTombstone ]
          (Table [ ArrayColumn [ 4 ] (Table [ ByteColumn "stan" ]) ])
        2: Attribute
          [ Time 13122518400 ]
          [ Priority 11 ]
          [ NotTombstone ]
          (Table
             [ IntColumn [ 1 ]
             , ArrayColumn [ 7 ] (Table [ ByteColumn "snowing" ])
             , IntColumn [ 1 ]
             , ArrayColumn [ 4 ] (Table [ ByteColumn "blue" ])
             , ArrayColumn [ 5 ] (Table [ ByteColumn "homer" ])
             , ArrayColumn [ 6 ] (Table [ ByteColumn "dinghy" ])
             ])
```