### PR TITLE
Reduce number of tests for merge

### DIFF
--- a/test/Test/Zebra/Foreign/Merge.hs
+++ b/test/Test/Zebra/Foreign/Merge.hs
@@ -253,5 +253,5 @@ prop_merge_2_block_2_files =
 
 return []
 tests :: IO Bool
-tests = $disorderCheckEnvAll TestRunMore
+tests = $disorderCheckEnvAll TestRunNormal
 


### PR DESCRIPTION
The whole test suite was taking 13m with TestRunMore here, 6m now.
I checked by reintroducing the stable sort and sort order bugs we found, and they are still found with only 100 tests. We upped it to More because I deleted some tests, but I ended up re-adding them so I think we can set it back to Normal.

! @jystic @tranma 