### PR TITLE
Reorganise data modules

### DIFF
--- a/main/zebra.hs
+++ b/main/zebra.hs
@@ -40,11 +40,11 @@ import qualified Zebra.Data.Block as Block
 import qualified Zebra.Data.Core as Core
 import qualified Zebra.Data.Entity as Entity
 import qualified Zebra.Data.Fact as Fact
-import           Zebra.Data.Schema (Schema)
 import qualified Zebra.Foreign.Block as Foreign
 import qualified Zebra.Foreign.Entity as Foreign
 import qualified Zebra.Merge.BlockC as Merge
 import qualified Zebra.Merge.Puller.File as Merge
+import           Zebra.Schema (Schema)
 import qualified Zebra.Serial as Serial
 import qualified Zebra.Serial.File as Serial
 

--- a/src/Zebra.hs
+++ b/src/Zebra.hs
@@ -1,7 +1,0 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-module Zebra (
-    module X
-  ) where
-
-import           Zebra.Data as X
-import           Zebra.Serial as X

--- a/src/Zebra/Data.hs
+++ b/src/Zebra/Data.hs
@@ -6,3 +6,4 @@ module Zebra.Data (
 import           Zebra.Data.Block as X
 import           Zebra.Data.Core as X
 import           Zebra.Data.Encoding as X
+import           Zebra.Data.Fact as X

--- a/src/Zebra/Data/Block/Block.hs
+++ b/src/Zebra/Data/Block/Block.hs
@@ -43,11 +43,12 @@ import           Zebra.Data.Block.Index
 import           Zebra.Data.Core
 import           Zebra.Data.Entity
 import           Zebra.Data.Fact
-import           Zebra.Data.Schema
-import           Zebra.Data.Table (Table, ValueError)
-import qualified Zebra.Data.Table as Table
-import           Zebra.Data.Table.Mutable (MutableError)
-import qualified Zebra.Data.Table.Mutable as MTable
+import           Zebra.Schema (Schema)
+import           Zebra.Table (Table, ValueError)
+import qualified Zebra.Table as Table
+import           Zebra.Table.Mutable (MutableError)
+import qualified Zebra.Table.Mutable as MTable
+import           Zebra.Value (Value)
 
 
 data Block a =

--- a/src/Zebra/Data/Encoding.hs
+++ b/src/Zebra/Data/Encoding.hs
@@ -43,7 +43,7 @@ import           Text.Printf (printf)
 import           X.Text.Show (gshowsPrec)
 
 import           Zebra.Data.Core
-import           Zebra.Data.Schema
+import           Zebra.Schema
 
 
 newtype Encoding =

--- a/src/Zebra/Data/Entity.hs
+++ b/src/Zebra/Data/Entity.hs
@@ -17,7 +17,7 @@ import           P
 import           X.Text.Show (gshowsPrec)
 
 import           Zebra.Data.Core
-import           Zebra.Data.Table
+import           Zebra.Table
 
 
 data Attribute a =

--- a/src/Zebra/Data/Fact.hs
+++ b/src/Zebra/Data/Fact.hs
@@ -2,35 +2,21 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module Zebra.Data.Fact (
     Fact(..)
-  , Value(..)
   , renderFact
-
-  , unit
-  , false
-  , true
-  , none
-  , some
 
   , FactRenderError(..)
   , renderFactRenderError
   ) where
 
-import           Data.Aeson ((.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encode.Pretty as Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as Char8
-import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import           Data.Thyme.Format (formatTime)
 import           Data.Typeable (Typeable)
 import qualified Data.Vector as Boxed
-import           Data.Word (Word8)
 
 import           GHC.Generics (Generic)
 
@@ -39,11 +25,11 @@ import           P hiding (some)
 import           System.Locale (defaultTimeLocale)
 
 import           Text.Printf (printf)
-import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Data.Core
-import           Zebra.Data.Schema (Schema)
-import qualified Zebra.Data.Schema as Schema
+import           Zebra.Schema (Schema)
+import           Zebra.Value (Value, ValueRenderError)
+import qualified Zebra.Value as Value
 
 
 data Fact =
@@ -56,61 +42,17 @@ data Fact =
     , factValue :: !(Maybe' Value)
     } deriving (Eq, Ord, Show, Generic, Typeable)
 
-data Value =
-    Byte !Word8
-  | Int !Int64
-  | Double !Double
-  | Enum !Int !Value
-  | Struct !(Boxed.Vector Value)
-  | Array !(Boxed.Vector Value)
-  | ByteArray !ByteString -- ^ Optimisation for Array [Byte, Byte, ..]
-    deriving (Eq, Ord, Show, Generic, Typeable)
-
 data FactRenderError =
-    FactValueSchemaMismatch !Value !Schema
+    FactValueRenderError !ValueRenderError
   | FactSchemaNotFoundForAttribute !AttributeId
     deriving (Eq, Ord, Show, Generic, Typeable)
 
 renderFactRenderError :: FactRenderError -> Text
 renderFactRenderError = \case
-  FactValueSchemaMismatch value schema ->
-    "Could not render fact, value did not match schema:" <>
-    "\n" <>
-    "\n  value =" <>
-    ppPrefix "\n    " value <>
-    "\n" <>
-    "\n  schema =" <>
-    ppPrefix "\n    " schema
+  FactValueRenderError err ->
+    Value.renderValueRenderError err
   FactSchemaNotFoundForAttribute (AttributeId aid) ->
     "Could not render fact, no schema found for attribute-id: " <> T.pack (show aid)
-
-------------------------------------------------------------------------
-
-unit :: Value
-unit =
-  Struct Boxed.empty
-
-false :: Value
-false =
-  Enum 0 unit
-
-true :: Value
-true =
-  Enum 1 unit
-
-none :: Value
-none =
-  Enum 0 unit
-
-some :: Value -> Value
-some =
-  Enum 1
-
-------------------------------------------------------------------------
-
-ppPrefix :: Show a => Text -> a -> Text
-ppPrefix prefix =
-  T.concat . fmap (prefix <>) . T.lines . T.pack . ppShow
 
 renderFact :: Boxed.Vector Schema -> Fact -> Either FactRenderError ByteString
 renderFact schemas fact = do
@@ -150,81 +92,4 @@ renderFactsetId (FactsetId factsetId) =
 
 renderMaybeValue :: Schema -> Maybe' Value -> Either FactRenderError ByteString
 renderMaybeValue schema =
-  maybe' (pure "NA") (renderValue schema)
-
-renderValue :: Schema -> Value -> Either FactRenderError ByteString
-renderValue schema value =
-  fmap (Lazy.toStrict . Aeson.encodePretty' aesonConfig) $ toAeson schema value
-
--- We use aeson-pretty so that the struct field names are sorted alphabetically
--- rather than by hash order.
-aesonConfig :: Aeson.Config
-aesonConfig =
-  Aeson.defConfig {
-      Aeson.confIndent =
-        Aeson.Spaces 0
-    , Aeson.confCompare =
-        compare
-    }
-
-toAeson :: Schema -> Value -> Either FactRenderError Aeson.Value
-toAeson schema value0 =
-  case schema of
-    Schema.Byte
-      | Byte x <- value0
-      ->
-        pure . Aeson.Number $ fromIntegral x
-
-    Schema.Int
-      | Int x <- value0
-      ->
-        pure . Aeson.Number $ fromIntegral x
-
-    Schema.Double
-      | Double x <- value0
-      ->
-        --
-        -- This maps NaN/Inf -> 'null', and uses 'fromFloatDigits' to convert
-        -- Double -> Scientific.
-        --
-        -- Don't use 'realToFrac' here, it converts the Double to a Scientific
-        -- with far more decimal places than a 64-bit floating point number can
-        -- possibly represent.
-        --
-        pure $ Aeson.toJSON x
-
-    Schema.Enum variant0 variants
-      | Enum tag value <- value0
-      , Just variant <- Schema.lookupVariant tag variant0 variants
-      -> do
-        payload <- toAeson (Schema.variantSchema variant) value
-        pure $ Aeson.object [
-            Schema.unVariantName (Schema.variantName variant) .= payload
-          ]
-
-    Schema.Struct fields
-      | Struct values <- value0
-      , Boxed.length fields == Boxed.length values
-      -> do
-        let
-          fnames =
-            fmap (Schema.unFieldName . Schema.fieldName) fields
-
-        fvalues <- Boxed.zipWithM toAeson (fmap Schema.fieldSchema fields) values
-
-        pure . Aeson.object . Boxed.toList $ Boxed.zipWith (.=) fnames fvalues
-
-    Schema.Array Schema.Byte
-      | ByteArray bs <- value0
-      ->
-        -- FIXME we need some metadata in the schema to say this is ok
-        pure . Aeson.String $ T.decodeUtf8 bs
-
-    Schema.Array element
-      | Array values <- value0
-      ->
-        fmap Aeson.Array $
-          traverse (toAeson element) values
-
-    _ ->
-      Left $ FactValueSchemaMismatch value0 schema
+  maybe' (pure "NA") (first FactValueRenderError . Value.render schema)

--- a/src/Zebra/Foreign/Entity.hs
+++ b/src/Zebra/Foreign/Entity.hs
@@ -31,10 +31,10 @@ import           X.Control.Monad.Trans.Either (EitherT)
 
 import           Zebra.Data.Core
 import           Zebra.Data.Entity
-import           Zebra.Data.Table
 import           Zebra.Foreign.Bindings
 import           Zebra.Foreign.Table
 import           Zebra.Foreign.Util
+import           Zebra.Table
 
 
 newtype CEntity =

--- a/src/Zebra/Foreign/Table.hs
+++ b/src/Zebra/Foreign/Table.hs
@@ -25,9 +25,9 @@ import           P
 
 import           X.Control.Monad.Trans.Either (EitherT, left)
 
-import           Zebra.Data.Table (Table(..), Column(..))
 import           Zebra.Foreign.Bindings
 import           Zebra.Foreign.Util
+import           Zebra.Table (Table(..), Column(..))
 
 
 newtype CTable =

--- a/src/Zebra/Merge/Base.hs
+++ b/src/Zebra/Merge/Base.hs
@@ -33,7 +33,7 @@ import qualified X.Data.Vector.Unboxed as Unboxed
 import qualified X.Text.Show as Show
 
 import           Zebra.Data
-import           Zebra.Data.Table (Table, TableError)
+import           Zebra.Table (Table, TableError)
 
 
 -- | A BlockDataId roughly corresponds to the id of the file, where a Table came from.

--- a/src/Zebra/Merge/BlockC.hs
+++ b/src/Zebra/Merge/BlockC.hs
@@ -28,11 +28,11 @@ import           X.Control.Monad.Trans.Either (EitherT, left)
 import qualified X.Data.Vector as Boxed
 
 import           Zebra.Data
-import           Zebra.Data.Schema (Schema)
 import           Zebra.Foreign.Block
 import           Zebra.Foreign.Entity
 import           Zebra.Foreign.Merge
 import           Zebra.Foreign.Util
+import           Zebra.Schema (Schema)
 
 
 data MergeError =

--- a/src/Zebra/Merge/Entity.hs
+++ b/src/Zebra/Merge/Entity.hs
@@ -24,9 +24,9 @@ import qualified X.Data.Vector.Generic as Generic
 import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data
-import           Zebra.Data.Table (Table)
-import qualified Zebra.Data.Table as Table
 import           Zebra.Merge.Base
+import           Zebra.Table (Table)
+import qualified Zebra.Table as Table
 
 
 entityValuesOfBlock :: Monad m => BlockDataId -> Block a -> Stream.Stream m (EntityValues a)

--- a/src/Zebra/Merge/Puller/File.hs
+++ b/src/Zebra/Merge/Puller/File.hs
@@ -29,9 +29,9 @@ import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data
-import           Zebra.Data.Schema (Schema)
-import           Zebra.Serial.File
 import           Zebra.Foreign.Util
+import           Zebra.Schema (Schema)
+import           Zebra.Serial.File
 
 
 data PullerError =

--- a/src/Zebra/Merge/Puller/List.hs
+++ b/src/Zebra/Merge/Puller/List.hs
@@ -20,9 +20,9 @@ import qualified X.Data.Vector as Boxed
 
 import           Zebra.Data
 import           Zebra.Data.Entity
-import           Zebra.Data.Schema (Schema)
 import           Zebra.Foreign.Entity
 import           Zebra.Merge.BlockC
+import           Zebra.Schema (Schema)
 
 
 mergeLists :: Int64 -> [[Block Schema]] -> EitherT MergeError IO [Entity ()]

--- a/src/Zebra/Schema.hs
+++ b/src/Zebra/Schema.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
-module Zebra.Data.Schema (
+module Zebra.Schema (
     Schema(..)
   , Field(..)
   , FieldName(..)

--- a/src/Zebra/Serial/Block.hs
+++ b/src/Zebra/Serial/Block.hs
@@ -39,11 +39,11 @@ import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data.Block
 import           Zebra.Data.Core
-import           Zebra.Data.Schema (Schema)
-import qualified Zebra.Data.Schema as Schema
-import           Zebra.Data.Table (Table(..), Column(..))
-import qualified Zebra.Data.Table as Table
+import           Zebra.Schema (Schema)
+import qualified Zebra.Schema as Schema
 import           Zebra.Serial.Array
+import           Zebra.Table (Table(..), Column(..))
+import qualified Zebra.Table as Table
 
 
 -- | Encode a zebra block.

--- a/src/Zebra/Serial/File.hs
+++ b/src/Zebra/Serial/File.hs
@@ -37,7 +37,7 @@ import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data
-import           Zebra.Data.Schema (Schema)
+import           Zebra.Schema (Schema)
 import           Zebra.Serial.Block
 import           Zebra.Serial.Header
 

--- a/src/Zebra/Serial/Header.hs
+++ b/src/Zebra/Serial/Header.hs
@@ -29,8 +29,8 @@ import           P
 
 import           Zebra.Data.Core
 import           Zebra.Data.Encoding
-import           Zebra.Data.Schema (Schema)
-import qualified Zebra.Data.Schema as Schema
+import           Zebra.Schema (Schema)
+import qualified Zebra.Schema as Schema
 import           Zebra.Serial.Array
 
 

--- a/src/Zebra/Value.hs
+++ b/src/Zebra/Value.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+module Zebra.Value (
+    Value(..)
+  , render
+
+  , ValueRenderError(..)
+  , renderValueRenderError
+
+  , unit
+  , false
+  , true
+  , none
+  , some
+  ) where
+
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as Aeson
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import           Data.Typeable (Typeable)
+import qualified Data.Vector as Boxed
+import           Data.Word (Word8)
+
+import           GHC.Generics (Generic)
+
+import           P hiding (some)
+
+import           Text.Show.Pretty (ppShow)
+
+import           Zebra.Schema (Schema)
+import qualified Zebra.Schema as Schema
+
+
+data Value =
+    Byte !Word8
+  | Int !Int64
+  | Double !Double
+  | Enum !Int !Value
+  | Struct !(Boxed.Vector Value)
+  | Array !(Boxed.Vector Value)
+  | ByteArray !ByteString -- ^ Optimisation for Array [Byte, Byte, ..]
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+data ValueRenderError =
+    ValueSchemaMismatch !Value !Schema
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+renderValueRenderError :: ValueRenderError -> Text
+renderValueRenderError = \case
+  ValueSchemaMismatch value schema ->
+    "Could not render value, schema did not match:" <>
+    "\n" <>
+    "\n  value =" <>
+    ppPrefix "\n    " value <>
+    "\n" <>
+    "\n  schema =" <>
+    ppPrefix "\n    " schema
+
+ppPrefix :: Show a => Text -> a -> Text
+ppPrefix prefix =
+  T.concat . fmap (prefix <>) . T.lines . T.pack . ppShow
+
+------------------------------------------------------------------------
+
+unit :: Value
+unit =
+  Struct Boxed.empty
+
+false :: Value
+false =
+  Enum 0 unit
+
+true :: Value
+true =
+  Enum 1 unit
+
+none :: Value
+none =
+  Enum 0 unit
+
+some :: Value -> Value
+some =
+  Enum 1
+
+------------------------------------------------------------------------
+
+render :: Schema -> Value -> Either ValueRenderError ByteString
+render schema value =
+  fmap (Lazy.toStrict . Aeson.encodePretty' aesonConfig) $ toAeson schema value
+
+-- We use aeson-pretty so that the struct field names are sorted alphabetically
+-- rather than by hash order.
+aesonConfig :: Aeson.Config
+aesonConfig =
+  Aeson.defConfig {
+      Aeson.confIndent =
+        Aeson.Spaces 0
+    , Aeson.confCompare =
+        compare
+    }
+
+toAeson :: Schema -> Value -> Either ValueRenderError Aeson.Value
+toAeson schema value0 =
+  case schema of
+    Schema.Byte
+      | Byte x <- value0
+      ->
+        pure . Aeson.Number $ fromIntegral x
+
+    Schema.Int
+      | Int x <- value0
+      ->
+        pure . Aeson.Number $ fromIntegral x
+
+    Schema.Double
+      | Double x <- value0
+      ->
+        --
+        -- This maps NaN/Inf -> 'null', and uses 'fromFloatDigits' to convert
+        -- Double -> Scientific.
+        --
+        -- Don't use 'realToFrac' here, it converts the Double to a Scientific
+        -- with far more decimal places than a 64-bit floating point number can
+        -- possibly represent.
+        --
+        pure $ Aeson.toJSON x
+
+    Schema.Enum variant0 variants
+      | Enum tag value <- value0
+      , Just variant <- Schema.lookupVariant tag variant0 variants
+      -> do
+        payload <- toAeson (Schema.variantSchema variant) value
+        pure $ Aeson.object [
+            Schema.unVariantName (Schema.variantName variant) .= payload
+          ]
+
+    Schema.Struct fields
+      | Struct values <- value0
+      , Boxed.length fields == Boxed.length values
+      -> do
+        let
+          fnames =
+            fmap (Schema.unFieldName . Schema.fieldName) fields
+
+        fvalues <- Boxed.zipWithM toAeson (fmap Schema.fieldSchema fields) values
+
+        pure . Aeson.object . Boxed.toList $ Boxed.zipWith (.=) fnames fvalues
+
+    Schema.Array Schema.Byte
+      | ByteArray bs <- value0
+      ->
+        -- FIXME we need some metadata in the schema to say this is ok
+        pure . Aeson.String $ T.decodeUtf8 bs
+
+    Schema.Array element
+      | Array values <- value0
+      ->
+        fmap Aeson.Array $
+          traverse (toAeson element) values
+
+    _ ->
+      Left $ ValueSchemaMismatch value0 schema

--- a/test/Test/Zebra/Data/Block.hs
+++ b/test/Test/Zebra/Data/Block.hs
@@ -17,8 +17,8 @@ import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Data.Block
 import           Zebra.Data.Core
-import           Zebra.Data.Schema (Schema)
-import           Zebra.Data.Table.Mutable (MutableError)
+import           Zebra.Schema (Schema)
+import           Zebra.Table.Mutable (MutableError)
 
 
 prop_roundtrip_facts :: Property

--- a/test/Test/Zebra/Foreign/Block.hs
+++ b/test/Test/Zebra/Foreign/Block.hs
@@ -33,10 +33,10 @@ import           X.Control.Monad.Trans.Either (EitherT, pattern EitherT, runEith
 import           Zebra.Data.Block
 import           Zebra.Data.Entity
 import qualified Zebra.Data.Entity as Entity
-import qualified Zebra.Data.Table as Table
 import           Zebra.Foreign.Block
 import           Zebra.Foreign.Entity
 import           Zebra.Foreign.Util
+import qualified Zebra.Table as Table
 
 
 data CommonError =

--- a/test/Test/Zebra/Foreign/Merge.hs
+++ b/test/Test/Zebra/Foreign/Merge.hs
@@ -34,9 +34,9 @@ import           Zebra.Foreign.Entity
 
 import           Zebra.Data.Block
 import           Zebra.Data.Core
-import           Zebra.Data.Schema
 import           Zebra.Data.Entity
 import           Zebra.Data.Fact
+import           Zebra.Schema
 
 import qualified Zebra.Merge.Puller.List as TestMerge
 

--- a/test/Test/Zebra/Merge/Entity.hs
+++ b/test/Test/Zebra/Merge/Entity.hs
@@ -24,11 +24,10 @@ import qualified X.Data.Vector as Boxed
 import qualified X.Data.Vector.Stream as Stream
 
 import           Zebra.Data
-import           Zebra.Data.Fact (Fact(..))
-import           Zebra.Data.Schema (Schema)
-import           Zebra.Data.Table (Table(..))
 import           Zebra.Merge.Base
 import           Zebra.Merge.Entity
+import           Zebra.Schema (Schema)
+import           Zebra.Table (Table(..))
 
 
 fakeBlockId :: BlockDataId

--- a/test/Test/Zebra/Serial/Block.hs
+++ b/test/Test/Zebra/Serial/Block.hs
@@ -21,8 +21,8 @@ import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Data.Block
 import           Zebra.Data.Core
-import qualified Zebra.Data.Table as Table
 import           Zebra.Serial.Block
+import qualified Zebra.Table as Table
 
 
 prop_roundtrip_from_facts :: Property

--- a/test/Test/Zebra/Table.hs
+++ b/test/Test/Zebra/Table.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Zebra.Data.Table where
+module Test.Zebra.Table where
 
 import           Disorder.Jack (Property, quickCheckAll)
 import           Disorder.Jack (gamble, tripping, arbitrary)
@@ -11,7 +11,7 @@ import           System.IO (IO)
 
 import           Test.Zebra.Jack
 
-import qualified Zebra.Data.Table as Table
+import qualified Zebra.Table as Table
 
 
 prop_roundtrip_splitAt :: Property

--- a/test/Test/Zebra/Table/Mutable.hs
+++ b/test/Test/Zebra/Table/Mutable.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Zebra.Data.Table.Mutable where
+module Test.Zebra.Table.Mutable where
 
 import           Control.Monad.ST (runST)
 
@@ -22,11 +22,11 @@ import           Text.Show.Pretty (ppShow)
 
 import           X.Control.Monad.Trans.Either (runEitherT)
 
-import           Zebra.Data.Fact (Value)
-import           Zebra.Data.Schema (Schema)
-import           Zebra.Data.Table (Table, ValueError)
-import qualified Zebra.Data.Table as Table
-import qualified Zebra.Data.Table.Mutable as MTable
+import           Zebra.Schema (Schema)
+import           Zebra.Table (Table, ValueError)
+import qualified Zebra.Table as Table
+import qualified Zebra.Table.Mutable as MTable
+import           Zebra.Value (Value)
 
 
 prop_default_table_vs_mtable :: Property

--- a/test/test.hs
+++ b/test/test.hs
@@ -3,8 +3,6 @@ import           Disorder.Core.Main
 import qualified Test.Zebra.Data.Block
 import qualified Test.Zebra.Data.Core
 import qualified Test.Zebra.Data.Encoding
-import qualified Test.Zebra.Data.Table
-import qualified Test.Zebra.Data.Table.Mutable
 import qualified Test.Zebra.Foreign.Block
 import qualified Test.Zebra.Foreign.Entity
 import qualified Test.Zebra.Foreign.Merge
@@ -14,6 +12,8 @@ import qualified Test.Zebra.Serial.Array
 import qualified Test.Zebra.Serial.Block
 import qualified Test.Zebra.Serial.File
 import qualified Test.Zebra.Serial.Header
+import qualified Test.Zebra.Table
+import qualified Test.Zebra.Table.Mutable
 
 main :: IO ()
 main =
@@ -21,8 +21,6 @@ main =
       Test.Zebra.Data.Block.tests
     , Test.Zebra.Data.Core.tests
     , Test.Zebra.Data.Encoding.tests
-    , Test.Zebra.Data.Table.Mutable.tests
-    , Test.Zebra.Data.Table.tests
     , Test.Zebra.Foreign.Block.tests
     , Test.Zebra.Foreign.Entity.tests
     , Test.Zebra.Foreign.Merge.tests
@@ -32,4 +30,6 @@ main =
     , Test.Zebra.Serial.Block.tests
     , Test.Zebra.Serial.File.tests
     , Test.Zebra.Serial.Header.tests
+    , Test.Zebra.Table.Mutable.tests
+    , Test.Zebra.Table.tests
     ]

--- a/zebra.cabal
+++ b/zebra.cabal
@@ -47,7 +47,10 @@ library
                     src
 
   exposed-modules:
-                    Zebra
+                    Zebra.Schema
+                    Zebra.Table
+                    Zebra.Table.Mutable
+                    Zebra.Value
 
                     Zebra.Data
                     Zebra.Data.Block
@@ -58,9 +61,6 @@ library
                     Zebra.Data.Encoding
                     Zebra.Data.Entity
                     Zebra.Data.Fact
-                    Zebra.Data.Schema
-                    Zebra.Data.Table
-                    Zebra.Data.Table.Mutable
 
                     Zebra.Foreign.Bindings
                     Zebra.Foreign.Block


### PR DESCRIPTION
- Rename `Zebra.Data.Schema` -> `Zebra.Schema`
- Rename `Zebra.Data.Table` -> `Zebra.Table`
- Rename `Zebra.Data.Table.Mutable` -> `Zebra.Table.Mutable`
- Moved value stuff out of `Zebra.Data.Fact` -> `Zebra.Value`

The rest of the `Zebra.Data` stuff is related to entities/facts, so that should be probably be moved to `Zebra.Fact` or something like that, but I'm not sure yet, baby steps.

! @amosr @tranma 
/jury approved @amosr