### PR TITLE
Only keep the ColumnIndex in the StateT when popping columns

### DIFF
--- a/src/Zebra/Table/Mutable.hs
+++ b/src/Zebra/Table/Mutable.hs
@@ -62,7 +62,7 @@ import           Zebra.Data.Fact
 import qualified Zebra.Data.Vector.Storable as Storable
 import           Zebra.Schema (Schema, Field(..), Variant(..))
 import qualified Zebra.Schema as Schema
-import           Zebra.Table (Table(..), Column(..))
+import           Zebra.Table (Table(..), Column(..), ColumnIndex(..))
 import qualified Zebra.Table as Table
 import           Zebra.Value (Value)
 import qualified Zebra.Value as Value
@@ -81,11 +81,6 @@ data MColumn s =
   | MDoubleColumn !(Grow MStorable.MVector s Double)
   | MArrayColumn !(Grow MStorable.MVector s Int64) !(MTable s)
     deriving (Generic, Typeable)
-
-newtype ColumnIndex =
-  ColumnIndex {
-      unColumnIndex :: Int
-    } deriving (Eq, Ord, Show, Num)
 
 schema :: MTable s -> Schema
 schema (MTable x _ _) =

--- a/test/Test/Zebra/Table.hs
+++ b/test/Test/Zebra/Table.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Zebra.Table where
 
+import qualified Data.Vector as Boxed
+
 import           Disorder.Jack (Property, quickCheckAll)
-import           Disorder.Jack (gamble, tripping, arbitrary)
+import           Disorder.Jack ((===), gamble, tripping, arbitrary, listOf1, counterexample)
 
 import           P
 
@@ -11,8 +13,22 @@ import           System.IO (IO)
 
 import           Test.Zebra.Jack
 
+import           Text.Show.Pretty (ppShow)
+
 import qualified Zebra.Table as Table
 
+
+prop_roundtrip_values :: Property
+prop_roundtrip_values =
+  gamble jSchema $ \schema ->
+  gamble (fmap (Boxed.fromList . toList) . listOf1 $ jValue schema) $ \values0 ->
+  either (flip counterexample False) id $ do
+    table <- first ppShow $ Table.concat =<< traverse (Table.fromRow schema) values0
+    values <- first ppShow $ Table.rows schema table
+    pure $
+      values0
+      ===
+      values
 
 prop_roundtrip_splitAt :: Property
 prop_roundtrip_splitAt =


### PR DESCRIPTION
This change makes the `Zebra.Table` match `Zebra.Table.Mutable` in the way we pop columns.

Essentially we now just keep the column index in the `StateT` instead of modifying the `Table` itself. This is good because it means that now a `Table` should never be in a state where it can't be matched to a schema.

! @amosr @tranma 