### PR TITLE
Make schema encode forwards compatible

### DIFF
--- a/test/Test/Zebra/Schema.hs
+++ b/test/Test/Zebra/Schema.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Zebra.Schema where
+
+import           Disorder.Jack (Property, quickCheckAll)
+import           Disorder.Jack (gamble, tripping)
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.Zebra.Jack
+
+import qualified Zebra.Schema as Schema
+
+
+prop_roundtrip_schema :: Property
+prop_roundtrip_schema =
+  gamble jSchema $
+    tripping Schema.encode Schema.decode
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll

--- a/test/test.hs
+++ b/test/test.hs
@@ -8,6 +8,7 @@ import qualified Test.Zebra.Foreign.Entity
 import qualified Test.Zebra.Foreign.Merge
 import qualified Test.Zebra.Foreign.Table
 import qualified Test.Zebra.Merge.Entity
+import qualified Test.Zebra.Schema
 import qualified Test.Zebra.Serial.Array
 import qualified Test.Zebra.Serial.Block
 import qualified Test.Zebra.Serial.File
@@ -26,6 +27,7 @@ main =
     , Test.Zebra.Foreign.Merge.tests
     , Test.Zebra.Foreign.Table.tests
     , Test.Zebra.Merge.Entity.tests
+    , Test.Zebra.Schema.tests
     , Test.Zebra.Serial.Array.tests
     , Test.Zebra.Serial.Block.tests
     , Test.Zebra.Serial.File.tests


### PR DESCRIPTION
We haven't used v2 of zebra in the wild yet, so I wanted to quickly change the schema encode/decode to match what we have planned for the new structure so we won't need to bump a version number on the file format when we roll it out.

This change will allow reading of all the new structure, but will be lossy when it writes out map tables and reversed columns.

! @amosr @tranma 
/jury approved @amosr