### PR TITLE
Support for marking binary as UTF-8 encoded

### DIFF
--- a/zebra-cli/src/Zebra/Command.hs
+++ b/zebra-cli/src/Zebra/Command.hs
@@ -151,7 +151,7 @@ withOutputPusher opts inputfile outputfile runWith = do
   let doPurge block = do
       pool <- liftIO $ IORef.readIORef poolRef
       outblock <- firstTshow $ Foreign.blockOfForeign block
-      builder <- firstT Block.renderBlockTableError . hoistEither $ Binary.bBlock header outblock
+      builder <- firstT Binary.renderBinaryEncodeError . hoistEither $ Binary.bBlock header outblock
       liftIO $ Builder.hPutBuilder outfd builder
       pool' <- liftIO $ Mempool.create
       liftIO $ IORef.writeIORef poolRef pool'

--- a/zebra-cli/test/cli/import/t01-array/expected
+++ b/zebra-cli/test/cli/import/t01-array/expected
@@ -8,18 +8,18 @@
           "fields": [
             {
               "name": "schleem",
-              "column": {
+              "schema": {
                 "enum": {
                   "variants": [
                     {
                       "name": "none",
-                      "column": {
+                      "schema": {
                         "unit": {}
                       }
                     },
                     {
                       "name": "some",
-                      "column": {
+                      "schema": {
                         "int": {}
                       }
                     }
@@ -29,10 +29,10 @@
             },
             {
               "name": "entity_id",
-              "column": {
-                "nested": {
-                  "table": {
-                    "binary": {}
+              "schema": {
+                "binary": {
+                  "encoding": {
+                    "utf8": {}
                   }
                 }
               }
@@ -47,5 +47,5 @@
 === Data ===
 {"entity_id":"abc","schleem":{"none":{}}}
 {"entity_id":"def","schleem":{"some":456}}
-{"entity_id":"schleem","schleem":{"some":789}}
-{"entity_id":"slhn\u000feo","schleem":{"none":{}}}
+{"entity_id":"ghi","schleem":{"some":789}}
+{"entity_id":"jkl","schleem":{"none":{}}}

--- a/zebra-cli/test/cli/import/t01-array/input.zschema
+++ b/zebra-cli/test/cli/import/t01-array/input.zschema
@@ -7,16 +7,16 @@
           "fields": [
             {
               "name": "schleem",
-              "column": {
+              "schema": {
                 "enum": {
                   "variants": [
                     {
                       "name": "none",
-                      "column": { "unit": {} }
+                      "schema": { "unit": {} }
                     },
                     {
                       "name": "some",
-                      "column": { "int": {} }
+                      "schema": { "int": {} }
                     }
                   ]
                 }
@@ -24,12 +24,10 @@
             },
             {
               "name": "entity_id",
-              "column": {
-                "nested": {
-                  "table": {
-                    "binary": {}
-                  }
-                }
+              "schema": {
+                 "binary": {
+                   "encoding": { "utf8": {} }
+                 }
               }
             }
           ]

--- a/zebra-cli/test/cli/import/t01-array/input.ztxt
+++ b/zebra-cli/test/cli/import/t01-array/input.ztxt
@@ -1,4 +1,4 @@
 {"schleem":{"none":{}}, "entity_id": "abc"}
 {"schleem":{"some":456}, "entity_id": "def"}
-{"schleem":{"some":789}, "entity_id": {"base64": "c2NobGVlbQ=="}}
-{"schleem":{"none":{}}, "entity_id": {"base64": "c2xobg9lbx=="}}
+{"schleem":{"some":789}, "entity_id": "ghi"}
+{"schleem":{"none":{}}, "entity_id": "jkl"}

--- a/zebra-cli/test/cli/import/t02-map/expected
+++ b/zebra-cli/test/cli/import/t02-map/expected
@@ -8,16 +8,16 @@
           "fields": [
             {
               "name": "entity_hash",
-              "column": {
+              "schema": {
                 "int": {}
               }
             },
             {
               "name": "entity_id",
-              "column": {
-                "nested": {
-                  "table": {
-                    "binary": {}
+              "schema": {
+                "binary": {
+                  "encoding": {
+                    "utf8": {}
                   }
                 }
               }
@@ -30,18 +30,14 @@
           "variants": [
             {
               "name": "cash",
-              "column": {
+              "schema": {
                 "double": {}
               }
             },
             {
               "name": "item",
-              "column": {
-                "nested": {
-                  "table": {
-                    "binary": {}
-                  }
-                }
+              "schema": {
+                "binary": {}
               }
             }
           ]
@@ -53,6 +49,6 @@
 
 === Data ===
 {"key":{"entity_hash":10,"entity_id":"barney"},"value":{"cash":27.6}}
-{"key":{"entity_hash":10,"entity_id":"homer"},"value":{"item":"duff"}}
+{"key":{"entity_hash":10,"entity_id":"homer"},"value":{"item":"ZHVmZg=="}}
 {"key":{"entity_hash":20,"entity_id":"marge"},"value":{"cash":45.1}}
-{"key":{"entity_hash":30,"entity_id":"lisa"},"value":{"item":"saxophone"}}
+{"key":{"entity_hash":30,"entity_id":"lisa"},"value":{"item":"c2F4b3Bob25l"}}

--- a/zebra-cli/test/cli/import/t02-map/input.zschema
+++ b/zebra-cli/test/cli/import/t02-map/input.zschema
@@ -7,14 +7,16 @@
           "fields": [
             {
               "name": "entity_hash",
-              "column": {
+              "schema": {
                 "int": {}
               }
             },
             {
               "name": "entity_id",
-              "column": {
-                "nested": { "table": { "binary": {} } }
+              "schema": {
+                "binary": {
+                  "encoding": { "utf8": {} }
+                }
               }
             }
           ]
@@ -25,14 +27,14 @@
           "variants": [
             {
               "name": "cash",
-              "column": {
+              "schema": {
                 "double": {}
               }
             },
             {
               "name": "item",
-              "column": {
-                "nested": { "table": { "binary": {} } }
+              "schema": {
+                "binary": {}
               }
             }
           ]

--- a/zebra-cli/test/cli/import/t02-map/input.ztxt
+++ b/zebra-cli/test/cli/import/t02-map/input.ztxt
@@ -1,4 +1,4 @@
 { "key": { "entity_hash": 10, "entity_id": "barney" }, "value": { "cash": 27.6 } }
-{ "key": { "entity_hash": 10, "entity_id": "homer" }, "value": { "item": "duff" } }
+{ "key": { "entity_hash": 10, "entity_id": "homer" }, "value": { "item": "ZHVmZg==" } }
 { "key": { "entity_hash": 20, "entity_id": "marge" }, "value": { "cash": 45.1 } }
-{ "key": { "entity_hash": 30, "entity_id": "lisa" }, "value": { "item": "saxophone" } }
+{ "key": { "entity_hash": 30, "entity_id": "lisa" }, "value": { "item": "c2F4b3Bob25l" } }

--- a/zebra-cli/test/cli/import/t03-binary/expected
+++ b/zebra-cli/test/cli/import/t03-binary/expected
@@ -2,7 +2,11 @@
 {
   "version": "v0",
   "schema": {
-    "binary": {}
+    "binary": {
+      "encoding": {
+        "utf8": {}
+      }
+    }
   }
 }
 

--- a/zebra-cli/test/cli/import/t03-binary/input.zschema
+++ b/zebra-cli/test/cli/import/t03-binary/input.zschema
@@ -1,6 +1,8 @@
 {
   "version": "v0",
   "schema": {
-    "binary": {}
+    "binary": {
+      "encoding": { "utf8": {} }
+    }
   }
 }

--- a/zebra-core/csrc/zebra_append.c
+++ b/zebra-core/csrc/zebra_append.c
@@ -193,7 +193,7 @@ void* zebra_ensure_capacity (anemone_mempool_t *pool, void *old, size_t size, in
     int64_t current_capacity = zebra_grow_array_capacity (old_used);
 
     if (old != NULL && required <= current_capacity) return old;
-    
+
     return zebra_grow_array (pool, old, size, old_used, zebra_grow_array_capacity (required) );
 }
 #define ZEBRA_ENSURE_CAPACITY(pool, in, oldcap, newcap) zebra_ensure_capacity (pool, in, sizeof (in[0]), oldcap, newcap )

--- a/zebra-core/csrc/zebra_block_split.c
+++ b/zebra-core/csrc/zebra_block_split.c
@@ -129,6 +129,8 @@ error_t zebra_table_pop_rows (
 
     switch (in_table->tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.encoding = in_table->of._binary.encoding;
+
             char *bytes = in_table->of._binary.bytes;
             out_table->of._binary.bytes = bytes;
             in_table->of._binary.bytes = bytes + n_rows;

--- a/zebra-core/csrc/zebra_clone.c
+++ b/zebra-core/csrc/zebra_clone.c
@@ -25,6 +25,7 @@ error_t zebra_agile_clone_table (anemone_mempool_t *pool, const zebra_table_t *t
     
     switch (table->tag) {
         case ZEBRA_TABLE_BINARY: {
+            into->of._binary.encoding = table->of._binary.encoding;
             into->of._binary.bytes = NULL;
             return ZEBRA_SUCCESS;
         }
@@ -139,6 +140,7 @@ error_t zebra_neritic_clone_table (
     out_table->tag = tag;
     switch (tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.encoding = in_table->of._binary.encoding;
             out_table->of._binary.bytes = in_table->of._binary.bytes;
             return ZEBRA_SUCCESS;
         }
@@ -267,6 +269,7 @@ error_t zebra_deep_clone_table (anemone_mempool_t *pool, const zebra_table_t *in
 
     switch (tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.encoding = in_table->of._binary.encoding;
             out_table->of._binary.bytes = ZEBRA_CLONE_ARRAY (pool, in_table->of._binary.bytes, row_capacity);
             return ZEBRA_SUCCESS;
         }

--- a/zebra-core/csrc/zebra_data.h
+++ b/zebra-core/csrc/zebra_data.h
@@ -19,6 +19,12 @@
 
 typedef int64_t bool64_t;
 
+// Encodings
+typedef enum zebra_binary_encoding {
+    ZEBRA_BINARY_NONE,
+    ZEBRA_BINARY_UTF8
+} zebra_binary_encoding_t;
+
 // Forward declarations for recursive structures
 struct zebra_column;
 typedef struct zebra_column zebra_column_t;
@@ -35,6 +41,7 @@ typedef enum zebra_table_tag {
 typedef union zebra_table_variant {
     // ZEBRA_TABLE_BINARY
     struct {
+        zebra_binary_encoding_t encoding;
         char* bytes;
     } _binary;
     // ZEBRA_TABLE_ARRAY
@@ -117,7 +124,7 @@ typedef union zebra_column_variant {
         // This requires a little more computation to remove the offset,
         // but allows us to reuse prefix sums from the middle of other arrays
         // without copying them.
-        // 
+        //
         // Example nested array:
         //
         //            [ [ 1 2 3 ]  [ 4 5 ]  [ 6 7 8 ] ]
@@ -133,7 +140,7 @@ typedef union zebra_column_variant {
         //  Lengths[i] = Scans[i+1] - Scans[i]
         //  Starts[i]  = Scans[i]   - Scans[0]
         //  Ends[i]    = Scans[i+1] - Scans[0]
-        // 
+        //
         // The inner table's row count is the total number of elements:
         //  table.row_count = Scans[length] - Scans[0]
         int64_t *indices;

--- a/zebra-core/src/Zebra/Foreign/Bindings.hsc
+++ b/zebra-core/src/Zebra/Foreign/Bindings.hsc
@@ -37,6 +37,10 @@ import Anemone.Foreign.Mempool (Mempool(..))
 #znum ZEBRA_UNPACK_BUFFER_TOO_SMALL
 #znum ZEBRA_UNPACK_BUFFER_TOO_LARGE
 
+-- Zebra.Table.Encoding.Binary
+#integral_t enum zebra_binary_encoding
+#znum ZEBRA_BINARY_NONE
+#znum ZEBRA_BINARY_UTF8
 
 -- Zebra.Table.Striped.Table
 #integral_t enum zebra_table_tag
@@ -46,6 +50,7 @@ import Anemone.Foreign.Mempool (Mempool(..))
 
 #starttype union zebra_table_variant
 -- ZEBRA_TABLE_BINARY
+#field _binary.encoding , <zebra_binary_encoding>
 #field _binary.bytes    , Ptr Word8
 -- ZEBRA_TABLE_ARRAY
 #field _array.values    , Ptr <zebra_column>

--- a/zebra-core/src/Zebra/Foreign/Util.hs
+++ b/zebra-core/src/Zebra/Foreign/Util.hs
@@ -55,6 +55,7 @@ data ForeignError =
   | ForeignTableNotEnoughCapacity
   | ForeignInvalidColumnType
   | ForeignInvalidTableType
+  | ForeignInvalidBinaryEncoding !Int
   | ForeignAttributeNotFound
   | ForeignNotEnoughBytes
   | ForeignNotEnoughRows

--- a/zebra-core/src/Zebra/Merge/BlockC.hs
+++ b/zebra-core/src/Zebra/Merge/BlockC.hs
@@ -67,7 +67,7 @@ mergeBlocks options files = do
   pool <- liftIO Mempool.create
   merger <- foreignT $ mergeManyInit pool
   let state0 = MergeState Map.empty pool merger Nothing
-  -- TODO bracket/catch and clean up last memory pool on error
+  -- FIXME bracket/catch and clean up last memory pool on error
   -- need to convert state into an IORef for this
   state <- foldM fill state0 files
   state' <- go state
@@ -112,7 +112,7 @@ mergeBlocks options files = do
         entities <- foreignT $ foreignEntitiesOfBlock (stateMempool state) cblock
         foreignT $ mergeManyPush (stateMempool state) (stateMergeMany state) (Boxed.convert entities)
 
-        -- TODO do this better
+        -- FIXME do this better
         case Boxed.uncons $ Boxed.reverse entities of
           Nothing ->
             return state

--- a/zebra-core/src/Zebra/Serial/Text/Schema.hs
+++ b/zebra-core/src/Zebra/Serial/Text/Schema.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as Text
 
 import           P
 
-import           Zebra.Serial.Json.Schema (SchemaVersion(..), pTableSchemaV0, ppTableSchema)
+import           Zebra.Serial.Json.Schema (SchemaVersion(..), pTableSchemaV1, ppTableSchema)
 import           Zebra.Serial.Json.Util
 import           Zebra.Table.Data
 import qualified Zebra.Table.Schema as Schema
@@ -50,7 +50,7 @@ pVersionedSchema =
     version <- withStructField "version" o pVersion
     case version of
       TextV0 ->
-        withStructField "schema" o pTableSchemaV0
+        withStructField "schema" o pTableSchemaV1
 
 ppVersionedSchema :: TextVersion -> Schema.Table -> Aeson.Value
 ppVersionedSchema version schema =
@@ -64,7 +64,7 @@ ppVersionedSchema version schema =
 schemaVersion :: TextVersion -> SchemaVersion
 schemaVersion = \case
   TextV0 ->
-    SchemaV0
+    SchemaV1
 
 pVersion :: Aeson.Value -> Aeson.Parser TextVersion
 pVersion =

--- a/zebra-core/src/Zebra/Table/Encoding.hs
+++ b/zebra-core/src/Zebra/Table/Encoding.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-} -- EncodeError
+module Zebra.Table.Encoding (
+    Binary(..)
+
+  , validateBinary
+  , validateUtf8
+  , decodeUtf8
+
+  , Utf8Error(..)
+  , renderUtf8Error
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Data.String (String)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Text.Encoding.Error (UnicodeException(..))
+import           Data.Word (Word8)
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           Text.Printf (printf)
+
+
+data Binary =
+    Utf8
+    deriving (Eq, Ord, Show, Generic)
+
+data Utf8Error =
+    Utf8Error !String !(Maybe Word8)
+    deriving (Eq, Ord, Show, Generic)
+
+renderUtf8Error :: Utf8Error -> Text
+renderUtf8Error = \case
+  Utf8Error msg Nothing ->
+    "Not valid UTF-8: " <> Text.pack msg
+  Utf8Error msg (Just byte) ->
+    Text.pack $
+      printf "Not valid UTF-8, cannot decode byte 0x%02x: %s" byte msg
+
+validateBinary :: Maybe Binary -> ByteString -> Either Utf8Error ()
+validateBinary = \case
+  Nothing ->
+    const $ pure ()
+  Just Utf8 ->
+    validateUtf8
+
+-- FIXME replace with something that doesn't allocate
+validateUtf8 :: ByteString -> Either Utf8Error ()
+validateUtf8 bs =
+  () <$ decodeUtf8 bs
+
+decodeUtf8 :: ByteString -> Either Utf8Error Text
+decodeUtf8 bs =
+  case Text.decodeUtf8' bs of
+    Left (DecodeError msg byte) ->
+      Left (Utf8Error msg byte)
+
+    Left (EncodeError msg _) ->
+      Left (Utf8Error msg Nothing) -- good.
+
+    Right txt ->
+      pure txt

--- a/zebra-core/src/Zebra/Table/Logical.hs
+++ b/zebra-core/src/Zebra/Table/Logical.hs
@@ -321,7 +321,7 @@ unionStep kvss =
 
 defaultTable :: Schema.Table -> Table
 defaultTable = \case
-  Schema.Binary ->
+  Schema.Binary _ ->
     Binary ByteString.empty
   Schema.Array _ ->
     Array Boxed.empty

--- a/zebra-core/src/Zebra/Table/Schema.hs
+++ b/zebra-core/src/Zebra/Table/Schema.hs
@@ -47,10 +47,11 @@ import           X.Data.Vector.Cons (Cons)
 import qualified X.Data.Vector.Cons as Cons
 
 import           Zebra.Table.Data
+import qualified Zebra.Table.Encoding as Encoding
 
 
 data Table =
-    Binary
+    Binary !(Maybe Encoding.Binary)
   | Array !Column
   | Map !Column !Column
     deriving (Eq, Ord, Show, Generic)
@@ -130,10 +131,10 @@ option =
 
 ------------------------------------------------------------------------
 
-takeBinary :: Table -> Either SchemaError ()
+takeBinary :: Table -> Either SchemaError (Maybe Encoding.Binary)
 takeBinary = \case
-  Binary ->
-    Right ()
+  Binary encoding ->
+    Right encoding
   x ->
     Left $ SchemaExpectedBinary x
 {-# INLINE takeBinary #-}

--- a/zebra-core/test/Test/Zebra/Serial/Binary/Block.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Binary/Block.hs
@@ -88,7 +88,7 @@ prop_roundtrip_indices =
 prop_roundtrip_tables :: Property
 prop_roundtrip_tables =
   gamble (Boxed.fromList <$> listOf (jStripedArray 1)) $ \xs ->
-    trippingSerial bTables (getTables $ fmap (unsafeTakeArray . Striped.schema) xs) xs
+    trippingSerialE bTables (getTables $ fmap (unsafeTakeArray . Striped.schema) xs) xs
 
 unsafeTakeArray :: Schema.Table -> Schema.Column
 unsafeTakeArray =

--- a/zebra-core/test/Test/Zebra/Serial/Binary/Header.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Binary/Header.hs
@@ -21,7 +21,7 @@ import           Zebra.Serial.Binary.Header
 
 prop_roundtrip_header_v2 :: Property
 prop_roundtrip_header_v2 =
-  gamble (mapOf jAttributeName jColumnSchema) $
+  gamble (mapOf jAttributeName $ fmap columnSchemaV0 jColumnSchema) $
     trippingSerial bHeaderV2 getHeaderV2
 
 prop_roundtrip_header_v3 :: Property
@@ -38,7 +38,7 @@ jHeader :: Jack Header
 jHeader =
   oneOf [
       HeaderV3 <$> jTableSchema
-    , HeaderV2 <$> mapOf jAttributeName jColumnSchema
+    , HeaderV2 <$> mapOf jAttributeName (fmap columnSchemaV0 jColumnSchema)
     ]
 
 mapOf :: Ord k => Jack k -> Jack v -> Jack (Map k v)

--- a/zebra-core/test/Test/Zebra/Serial/Binary/Striped.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Binary/Striped.hs
@@ -20,13 +20,13 @@ prop_roundtrip_table :: Property
 prop_roundtrip_table =
   gamble jBinaryVersion $ \version ->
   gamble (jStriped 1) $ \table ->
-    trippingSerial (bTable version) (getTable version 1 $ Striped.schema table) table
+    trippingSerialE (bTable version) (getTable version 1 $ Striped.schema table) table
 
 prop_roundtrip_column :: Property
 prop_roundtrip_column =
   gamble jBinaryVersion $ \version ->
   gamble (jStripedColumn 1) $ \column ->
-    trippingSerial (bColumn version) (getColumn version 1 $ Striped.schemaColumn column) column
+    trippingSerialE (bColumn version) (getColumn version 1 $ Striped.schemaColumn column) column
 
 return []
 tests :: IO Bool

--- a/zebra-core/test/Test/Zebra/Serial/Json/Schema.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Json/Schema.hs
@@ -3,7 +3,7 @@
 module Test.Zebra.Serial.Json.Schema where
 
 import           Disorder.Jack (Property, quickCheckAll)
-import           Disorder.Jack (gamble, tripping)
+import           Disorder.Jack (gamble)
 
 import           P
 
@@ -14,10 +14,15 @@ import           Test.Zebra.Jack
 import           Zebra.Serial.Json.Schema
 
 
-prop_roundtrip_schema :: Property
-prop_roundtrip_schema =
+prop_roundtrip_schema_v0 :: Property
+prop_roundtrip_schema_v0 =
+  gamble (tableSchemaV0 <$> jTableSchema) $
+    trippingBoth (pure . encodeSchema SchemaV0) (decodeSchema SchemaV0)
+
+prop_roundtrip_schema_v1 :: Property
+prop_roundtrip_schema_v1 =
   gamble jTableSchema $
-    tripping (encodeSchema SchemaV0) (decodeSchema SchemaV0)
+    trippingBoth (pure . encodeSchema SchemaV1) (decodeSchema SchemaV1)
 
 return []
 tests :: IO Bool

--- a/zebra-core/test/Test/Zebra/Serial/Text/Schema.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Text/Schema.hs
@@ -3,7 +3,7 @@
 module Test.Zebra.Serial.Text.Schema where
 
 import           Disorder.Jack (Property, quickCheckAll)
-import           Disorder.Jack (gamble, tripping)
+import           Disorder.Jack (gamble)
 
 import           P
 
@@ -17,7 +17,7 @@ import           Zebra.Serial.Text.Schema
 prop_roundtrip_schema :: Property
 prop_roundtrip_schema =
   gamble jTableSchema $
-    tripping (encodeSchema TextV0) decodeSchema
+    trippingBoth (pure . encodeSchema TextV0) (decodeSchema)
 
 return []
 tests :: IO Bool

--- a/zebra-core/zebra-core.cabal
+++ b/zebra-core/zebra-core.cabal
@@ -98,6 +98,7 @@ library
                     Zebra.Serial.Text.Striped
 
                     Zebra.Table.Data
+                    Zebra.Table.Encoding
                     Zebra.Table.Logical
                     Zebra.Table.Schema
                     Zebra.Table.Striped


### PR DESCRIPTION
This adds the concept of encoding to a schema.

The first schema type to get an encoding is `binary`, it can be marked as being UTF-8 encoded.

In the future we will add encodings to `int` for dates and times, and maybe one for `double` to denote that they don't contain `NaN` or `Infinity`.

Validation that a binary table is actually UTF-8 encoded occurs on encode and decode in both the text and binary file formats. Hopefully this isn't too costly.

I made some changes to the schema structure which are not backwards compatible, so this will break any v3 files we have lying around unfortunately, but we don't have any in production, so I think this is ok.

! @tranma 