### PR TITLE
Schema supports default annotation

### DIFF
--- a/zebra-core/csrc/zebra_block_split.c
+++ b/zebra-core/csrc/zebra_block_split.c
@@ -66,6 +66,8 @@ error_t zebra_column_pop_rows (
         }
 
         case ZEBRA_COLUMN_INT: {
+            out_data->_int.default_ = in_data->_int.default_;
+
             int64_t *i = in_data->_int.values;
             out_data->_int.values = i;
             in_data->_int.values = i + n_rows;
@@ -74,6 +76,8 @@ error_t zebra_column_pop_rows (
         }
 
         case ZEBRA_COLUMN_DOUBLE: {
+            out_data->_int.default_ = in_data->_int.default_;
+
             double *d = in_data->_double.values;
             out_data->_double.values = d;
             in_data->_double.values = d + n_rows;
@@ -82,6 +86,8 @@ error_t zebra_column_pop_rows (
         }
 
         case ZEBRA_COLUMN_ENUM: {
+            out_data->_enum.default_ = in_data->_enum.default_;
+
             int64_t *tags = in_data->_enum.tags;
             out_data->_enum.tags = tags;
             in_data->_enum.tags = tags + n_rows;
@@ -90,6 +96,8 @@ error_t zebra_column_pop_rows (
         }
 
         case ZEBRA_COLUMN_STRUCT: {
+            out_data->_struct.default_ = in_data->_struct.default_;
+
             return zebra_named_columns_pop_rows (pool, n_rows, &in_data->_struct.columns, &out_data->_struct.columns);
         }
 
@@ -129,6 +137,7 @@ error_t zebra_table_pop_rows (
 
     switch (in_table->tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.default_ = in_table->of._binary.default_;
             out_table->of._binary.encoding = in_table->of._binary.encoding;
 
             char *bytes = in_table->of._binary.bytes;
@@ -139,11 +148,13 @@ error_t zebra_table_pop_rows (
         }
 
         case ZEBRA_TABLE_ARRAY: {
+            out_table->of._array.default_ = in_table->of._array.default_;
             out_table->of._array.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             return zebra_column_pop_rows (pool, n_rows, in_table->of._array.values, out_table->of._array.values);
         }
 
         case ZEBRA_TABLE_MAP: {
+            out_table->of._map.default_ = in_table->of._map.default_;
             out_table->of._map.keys = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             out_table->of._map.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             error_t err = zebra_column_pop_rows (pool, n_rows, in_table->of._map.keys, out_table->of._map.keys);

--- a/zebra-core/csrc/zebra_clone.c
+++ b/zebra-core/csrc/zebra_clone.c
@@ -22,20 +22,23 @@ error_t zebra_agile_clone_table (anemone_mempool_t *pool, const zebra_table_t *t
     into->row_count = 0;
     into->row_capacity = 0;
     into->tag = table->tag;
-    
+
     switch (table->tag) {
         case ZEBRA_TABLE_BINARY: {
+            into->of._binary.default_ = table->of._binary.default_;
             into->of._binary.encoding = table->of._binary.encoding;
             into->of._binary.bytes = NULL;
             return ZEBRA_SUCCESS;
         }
 
         case ZEBRA_TABLE_ARRAY: {
+            into->of._array.default_ = table->of._array.default_;
             into->of._array.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             return zebra_agile_clone_column (pool, table->of._array.values, into->of._array.values);
         }
 
         case ZEBRA_TABLE_MAP: {
+            into->of._map.default_ = table->of._map.default_;
             into->of._map.keys = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             into->of._map.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
 
@@ -89,18 +92,22 @@ error_t zebra_agile_clone_column (
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_INT:
+            out_data->_int.default_ = in_data->_int.default_;
             out_data->_int.values = NULL;
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_DOUBLE:
+            out_data->_double.default_ = in_data->_double.default_;
             out_data->_double.values = NULL;
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_ENUM:
+            out_data->_enum.default_ = in_data->_enum.default_;
             out_data->_enum.tags = NULL;
             return zebra_agile_clone_named_column (pool, &in_data->_enum.columns, &out_data->_enum.columns);
 
         case ZEBRA_COLUMN_STRUCT:
+            out_data->_struct.default_ = in_data->_struct.default_;
             return zebra_agile_clone_named_column (pool, &in_data->_struct.columns, &out_data->_struct.columns);
 
         case ZEBRA_COLUMN_NESTED:
@@ -140,23 +147,26 @@ error_t zebra_neritic_clone_table (
     out_table->tag = tag;
     switch (tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.default_ = in_table->of._binary.default_;
             out_table->of._binary.encoding = in_table->of._binary.encoding;
             out_table->of._binary.bytes = in_table->of._binary.bytes;
             return ZEBRA_SUCCESS;
         }
 
         case ZEBRA_TABLE_ARRAY: {
+            out_table->of._array.default_ = in_table->of._array.default_;
             out_table->of._array.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
-            return zebra_neritic_clone_column (pool, in_table->of._array.values, out_table->of._array.values); 
+            return zebra_neritic_clone_column (pool, in_table->of._array.values, out_table->of._array.values);
         }
 
         case ZEBRA_TABLE_MAP: {
+            out_table->of._map.default_ = in_table->of._map.default_;
             out_table->of._map.keys = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             out_table->of._map.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
 
-            error_t err = zebra_neritic_clone_column (pool, in_table->of._map.keys, out_table->of._map.keys); 
+            error_t err = zebra_neritic_clone_column (pool, in_table->of._map.keys, out_table->of._map.keys);
             if (err) return err;
-            return zebra_neritic_clone_column (pool, in_table->of._map.values, out_table->of._map.values); 
+            return zebra_neritic_clone_column (pool, in_table->of._map.values, out_table->of._map.values);
         }
 
         default: {
@@ -205,18 +215,22 @@ error_t zebra_neritic_clone_column (
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_INT:
+            out_data->_int.default_ = in_data->_int.default_;
             out_data->_int.values = in_data->_int.values;
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_DOUBLE:
+            out_data->_double.default_ = in_data->_double.default_;
             out_data->_double.values = in_data->_double.values;
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_ENUM:
+            out_data->_enum.default_ = in_data->_enum.default_;
             out_data->_enum.tags = in_data->_enum.tags;
             return zebra_neritic_clone_named_column (pool, &in_data->_enum.columns, &out_data->_enum.columns);
 
         case ZEBRA_COLUMN_STRUCT:
+            out_data->_struct.default_ = in_data->_struct.default_;
             return zebra_neritic_clone_named_column (pool, &in_data->_struct.columns, &out_data->_struct.columns);
 
         case ZEBRA_COLUMN_NESTED:
@@ -269,23 +283,26 @@ error_t zebra_deep_clone_table (anemone_mempool_t *pool, const zebra_table_t *in
 
     switch (tag) {
         case ZEBRA_TABLE_BINARY: {
+            out_table->of._binary.default_ = in_table->of._binary.default_;
             out_table->of._binary.encoding = in_table->of._binary.encoding;
             out_table->of._binary.bytes = ZEBRA_CLONE_ARRAY (pool, in_table->of._binary.bytes, row_capacity);
             return ZEBRA_SUCCESS;
         }
 
         case ZEBRA_TABLE_ARRAY: {
+            out_table->of._array.default_ = in_table->of._array.default_;
             out_table->of._array.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
-            return zebra_deep_clone_column (pool, row_capacity, in_table->of._array.values, out_table->of._array.values); 
+            return zebra_deep_clone_column (pool, row_capacity, in_table->of._array.values, out_table->of._array.values);
         }
 
         case ZEBRA_TABLE_MAP: {
+            out_table->of._map.default_ = in_table->of._map.default_;
             out_table->of._map.keys = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
             out_table->of._map.values = anemone_mempool_alloc (pool, sizeof (zebra_column_t) );
 
-            error_t err = zebra_deep_clone_column (pool, row_capacity, in_table->of._map.keys, out_table->of._map.keys); 
+            error_t err = zebra_deep_clone_column (pool, row_capacity, in_table->of._map.keys, out_table->of._map.keys);
             if (err) return err;
-            return zebra_deep_clone_column (pool, row_capacity, in_table->of._map.values, out_table->of._map.values); 
+            return zebra_deep_clone_column (pool, row_capacity, in_table->of._map.values, out_table->of._map.values);
         }
 
         default: {
@@ -336,18 +353,22 @@ error_t zebra_deep_clone_column (
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_INT:
+            out_data->_int.default_ = in_data->_int.default_;
             out_data->_int.values = ZEBRA_CLONE_ARRAY (pool, in_data->_int.values, capacity);
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_DOUBLE:
+            out_data->_double.default_ = in_data->_double.default_;
             out_data->_double.values = ZEBRA_CLONE_ARRAY (pool, in_data->_double.values, capacity);
             return ZEBRA_SUCCESS;
 
         case ZEBRA_COLUMN_ENUM:
+            out_data->_enum.default_ = in_data->_enum.default_;
             out_data->_enum.tags = ZEBRA_CLONE_ARRAY (pool, in_data->_enum.tags, capacity);
             return zebra_deep_clone_named_column (pool, capacity, &in_data->_enum.columns, &out_data->_enum.columns);
 
         case ZEBRA_COLUMN_STRUCT:
+            out_data->_struct.default_ = in_data->_struct.default_;
             return zebra_deep_clone_named_column (pool, capacity, &in_data->_struct.columns, &out_data->_struct.columns);
 
         case ZEBRA_COLUMN_NESTED:

--- a/zebra-core/csrc/zebra_data.h
+++ b/zebra-core/csrc/zebra_data.h
@@ -19,6 +19,12 @@
 
 typedef int64_t bool64_t;
 
+// Default
+typedef enum zebra_default {
+    ZEBRA_DEFAULT_DENY,
+    ZEBRA_DEFAULT_ALLOW
+} zebra_default_t;
+
 // Encodings
 typedef enum zebra_binary_encoding {
     ZEBRA_BINARY_NONE,
@@ -41,15 +47,18 @@ typedef enum zebra_table_tag {
 typedef union zebra_table_variant {
     // ZEBRA_TABLE_BINARY
     struct {
+        zebra_default_t default_;
         zebra_binary_encoding_t encoding;
         char* bytes;
     } _binary;
     // ZEBRA_TABLE_ARRAY
     struct {
+        zebra_default_t default_;
         zebra_column_t* values;
     } _array;
     // ZEBRA_TABLE_MAP
     struct {
+        zebra_default_t default_;
         zebra_column_t* keys;
         zebra_column_t* values;
     } _map;
@@ -102,16 +111,20 @@ typedef union zebra_column_variant {
     struct {
     } _unit;
     struct {
+        zebra_default_t default_;
         int64_t *values;
     } _int;
     struct {
+        zebra_default_t default_;
         double *values;
     } _double;
     struct {
+        zebra_default_t default_;
         int64_t *tags;
         zebra_named_columns_t columns;
     } _enum;
     struct {
+        zebra_default_t default_;
         zebra_named_columns_t columns;
     } _struct;
     struct {

--- a/zebra-core/src/Zebra/Factset/Fact.hs
+++ b/zebra-core/src/Zebra/Factset/Fact.hs
@@ -32,6 +32,7 @@ import           Text.Show.Pretty (ppShow)
 
 import           Zebra.Factset.Data
 import           Zebra.Serial.Json
+import           Zebra.Table.Data
 import qualified Zebra.Table.Logical as Logical
 import qualified Zebra.Table.Schema as Schema
 import           Zebra.Table.Striped (StripedError)
@@ -98,7 +99,7 @@ toValueTable schemas facts =
         Boxed.map (fromMaybe' defaultValue . factValue) $
         Boxed.filter matchId facts
 
-    first FactStripedError . Striped.fromLogical (Schema.Array schema) $ Logical.Array values
+    first FactStripedError . Striped.fromLogical (Schema.Array DenyDefault schema) $ Logical.Array values
 
 render :: Boxed.Vector Schema.Column -> Fact -> Either FactRenderError ByteString
 render schemas fact = do

--- a/zebra-core/src/Zebra/Foreign/Bindings.hsc
+++ b/zebra-core/src/Zebra/Foreign/Bindings.hsc
@@ -37,6 +37,11 @@ import Anemone.Foreign.Mempool (Mempool(..))
 #znum ZEBRA_UNPACK_BUFFER_TOO_SMALL
 #znum ZEBRA_UNPACK_BUFFER_TOO_LARGE
 
+-- Zebra.Table.Data.Default
+#integral_t enum zebra_default
+#znum ZEBRA_DEFAULT_DENY
+#znum ZEBRA_DEFAULT_ALLOW
+
 -- Zebra.Table.Encoding.Binary
 #integral_t enum zebra_binary_encoding
 #znum ZEBRA_BINARY_NONE
@@ -50,11 +55,14 @@ import Anemone.Foreign.Mempool (Mempool(..))
 
 #starttype union zebra_table_variant
 -- ZEBRA_TABLE_BINARY
+#field _binary.default_ , <zebra_default>
 #field _binary.encoding , <zebra_binary_encoding>
 #field _binary.bytes    , Ptr Word8
 -- ZEBRA_TABLE_ARRAY
+#field _array.default_  , <zebra_default>
 #field _array.values    , Ptr <zebra_column>
 -- ZEBRA_TABLE_MAP
+#field _map.default_    , <zebra_default>
 #field _map.keys        , Ptr <zebra_column>
 #field _map.values      , Ptr <zebra_column>
 #stoptype
@@ -91,13 +99,17 @@ import Anemone.Foreign.Mempool (Mempool(..))
 #starttype union zebra_column_variant
 -- ZEBRA_COLUMN_UNIT (empty)
 -- ZEBRA_COLUMN_INT
+#field _int.default_    , <zebra_default>
 #field _int.values      , Ptr Int64
 -- ZEBRA_COLUMN_DOUBLE
+#field _double.default_ , <zebra_default>
 #field _double.values   , Ptr Double
 -- ZEBRA_COLUMN_ENUM
+#field _enum.default_   , <zebra_default>
 #field _enum.tags       , Ptr Int64
 #field _enum.columns    , <zebra_named_columns>
 -- ZEBRA_COLUMN_STRUCT
+#field _struct.default_ , <zebra_default>
 #field _struct.columns  , <zebra_named_columns>
 -- ZEBRA_COLUMN_NESTED
 #field _nested.indices  , Ptr Int64

--- a/zebra-core/src/Zebra/Foreign/Util.hs
+++ b/zebra-core/src/Zebra/Foreign/Util.hs
@@ -55,6 +55,7 @@ data ForeignError =
   | ForeignTableNotEnoughCapacity
   | ForeignInvalidColumnType
   | ForeignInvalidTableType
+  | ForeignInvalidDefault !Int
   | ForeignInvalidBinaryEncoding !Int
   | ForeignAttributeNotFound
   | ForeignNotEnoughBytes

--- a/zebra-core/src/Zebra/Serial/Binary/Block.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Block.hs
@@ -57,6 +57,7 @@ import           Zebra.Factset.Table
 import           Zebra.Serial.Binary.Array
 import           Zebra.Serial.Binary.Data
 import           Zebra.Serial.Binary.Table
+import           Zebra.Table.Data
 import qualified Zebra.Table.Schema as Schema
 import qualified Zebra.Table.Striped as Striped
 
@@ -416,7 +417,7 @@ getTables schemas = do
         Nothing ->
           fail $ "Cannot read table, unknown attribute-id: " <> show aid
         Just schema ->
-          getTable BinaryV2 n (Schema.Array schema)
+          getTable BinaryV2 n (Schema.Array DenyDefault schema)
 
   Boxed.zipWithM get ids counts
 {-# INLINABLE getTables #-}

--- a/zebra-core/src/Zebra/Serial/Binary/Header.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Header.hs
@@ -37,6 +37,7 @@ import           Zebra.Factset.Data
 import           Zebra.Serial.Binary.Array
 import           Zebra.Serial.Binary.Data
 import           Zebra.Serial.Json.Schema
+import           Zebra.Table.Data
 import qualified Zebra.Table.Schema as Schema
 
 
@@ -110,7 +111,7 @@ bHeaderV2 features =
 
     schema =
       bStrings .
-      fmap (encodeSchema SchemaV0 . Schema.Array) .
+      fmap (encodeSchema SchemaV0 . Schema.Array DenyDefault) .
       Boxed.fromList $
       Map.elems features
   in
@@ -128,7 +129,7 @@ getHeaderV2 = do
   let
     cs =
       either (fail . Text.unpack . Schema.renderSchemaError) id $
-      traverse Schema.takeArray ts
+      traverse (fmap snd . Schema.takeArray) ts
 
   pure .
     Map.fromList . toList $

--- a/zebra-core/src/Zebra/Serial/Text/Logical.hs
+++ b/zebra-core/src/Zebra/Serial/Text/Logical.hs
@@ -93,19 +93,19 @@ encodeJsonRows keyOrder =
 encodeLogicalBlock :: Schema.Table -> Logical.Table -> Either TextLogicalEncodeError ByteString
 encodeLogicalBlock schema table0 =
   case schema of
-    Schema.Binary encoding
+    Schema.Binary _ encoding
       | Logical.Binary bs <- table0
       -> do
         () <- first TextLogicalEncodeUtf8 $ Encoding.validateBinary encoding bs
         pure bs
 
-    Schema.Array element
+    Schema.Array _ element
       | Logical.Array xs <- table0
       ->
         first TextLogicalEncodeError $
           encodeJsonRows ["key"] <$> traverse (ppValue element) xs
 
-    Schema.Map kschema vschema
+    Schema.Map _ kschema vschema
       | Logical.Map kvs <- table0
       ->
         first TextLogicalEncodeError $ do
@@ -137,26 +137,26 @@ decodeJsonRows p =
 decodeLogicalBlock :: Schema.Table -> ByteString -> Either TextLogicalDecodeError Logical.Table
 decodeLogicalBlock schema bs =
   case schema of
-    Schema.Binary encoding -> do
+    Schema.Binary _ encoding -> do
       () <- first TextLogicalDecodeUtf8 $ Encoding.validateBinary encoding bs
       pure $ Logical.Binary bs
 
-    Schema.Array element ->
+    Schema.Array _ element ->
       first TextLogicalDecodeError $
         Logical.Array <$> decodeJsonRows (pValue element) bs
 
-    Schema.Map kschema vschema ->
+    Schema.Map _ kschema vschema ->
       first TextLogicalDecodeError $
         Logical.Map . Map.fromList . Boxed.toList <$> decodeJsonRows (pPair kschema vschema) bs
 {-# INLINABLE decodeLogicalBlock #-}
 
 needsAlignment :: Schema.Table -> Bool
 needsAlignment = \case
-  Schema.Binary _ ->
+  Schema.Binary _ _ ->
     False
-  Schema.Array _ ->
+  Schema.Array _ _ ->
     True
-  Schema.Map _ _ ->
+  Schema.Map _ _ _ ->
     True
 {-# INLINABLE needsAlignment #-}
 

--- a/zebra-core/src/Zebra/Table/Data.hs
+++ b/zebra-core/src/Zebra/Table/Data.hs
@@ -11,6 +11,7 @@ module Zebra.Table.Data (
   , Variant(..)
   , VariantName(..)
   , Tag(..)
+  , Default(..)
 
   , hasVariant
   , lookupVariant
@@ -90,6 +91,17 @@ newtype Tag =
 instance Show Tag where
   showsPrec =
     gshowsPrec
+
+--
+-- Ideally this would contain a Zebra.Table.Logical.Table/Value which is the
+-- default value for the Table/Column. However, all we need right now is to
+-- be able to default to empty lists/maps and 'none' enum values, so we go
+-- for a simpler approach where the default value is implied.
+--
+data Default =
+    DenyDefault  -- ^ Table/column can NOT be replaced by a default value if missing.
+  | AllowDefault -- ^ Table/column can be replaced by a default value if missing.
+    deriving (Eq, Ord, Show, Generic)
 
 ------------------------------------------------------------------------
 

--- a/zebra-core/src/Zebra/Table/Logical.hs
+++ b/zebra-core/src/Zebra/Table/Logical.hs
@@ -329,11 +329,11 @@ unionStep kvss =
 
 empty :: Schema.Table -> Table
 empty = \case
-  Schema.Binary _ ->
+  Schema.Binary _ _ ->
     Binary ByteString.empty
-  Schema.Array _ ->
+  Schema.Array _ _ ->
     Array Boxed.empty
-  Schema.Map _ _ ->
+  Schema.Map _ _ _ ->
     Map Map.empty
 {-# INLINABLE empty #-}
 
@@ -346,13 +346,13 @@ defaultValue :: Schema.Column -> Value
 defaultValue = \case
   Schema.Unit ->
     Unit
-  Schema.Int ->
+  Schema.Int _ ->
     Int 0
-  Schema.Double ->
+  Schema.Double _ ->
     Double 0
-  Schema.Enum vs ->
+  Schema.Enum _ vs ->
     Enum 0 . defaultValue . variantData $ Cons.head vs
-  Schema.Struct fs ->
+  Schema.Struct _ fs ->
     Struct $ fmap (defaultValue . fieldData) fs
   Schema.Nested s ->
     Nested $ defaultTable s

--- a/zebra-core/test/Test/Zebra/Serial/Binary/Block.hs
+++ b/zebra-core/test/Test/Zebra/Serial/Binary/Block.hs
@@ -29,6 +29,7 @@ import           Zebra.Factset.Block
 import           Zebra.Factset.Data
 import           Zebra.Serial.Binary.Block
 import           Zebra.Serial.Binary.Data
+import           Zebra.Table.Data
 import qualified Zebra.Table.Schema as Schema
 import qualified Zebra.Table.Striped as Striped
 
@@ -87,12 +88,12 @@ prop_roundtrip_indices =
 
 prop_roundtrip_tables :: Property
 prop_roundtrip_tables =
-  gamble (Boxed.fromList <$> listOf (jStripedArray 1)) $ \xs ->
-    trippingSerialE bTables (getTables $ fmap (unsafeTakeArray . Striped.schema) xs) xs
+  gamble (Boxed.fromList <$> listOf (jStripedColumn 1)) $ \xs ->
+    trippingSerialE bTables (getTables $ fmap Striped.schemaColumn xs) (fmap (Striped.Array DenyDefault) xs)
 
 unsafeTakeArray :: Schema.Table -> Schema.Column
 unsafeTakeArray =
-  either (Savage.error . ppShow) id . Schema.takeArray
+  either (Savage.error . ppShow) snd . Schema.takeArray
 
 return []
 tests :: IO Bool

--- a/zebra-core/test/Test/Zebra/Table/Striped.hs
+++ b/zebra-core/test/Test/Zebra/Table/Striped.hs
@@ -13,9 +13,10 @@ import           Test.Zebra.Jack
 
 import           Text.Show.Pretty (ppShow)
 
+import           Zebra.Table.Data
+import qualified Zebra.Table.Logical as Logical
 import qualified Zebra.Table.Schema as Schema
 import qualified Zebra.Table.Striped as Striped
-import qualified Zebra.Table.Logical as Logical
 
 
 prop_roundtrip_values :: Property
@@ -32,7 +33,7 @@ prop_roundtrip_values =
 
 prop_append_array_table :: Property
 prop_append_array_table =
-  gamble (Schema.Array <$> jColumnSchema) $ \schema ->
+  gamble (Schema.Array DenyDefault <$> jColumnSchema) $ \schema ->
   gamble (jSizedLogical schema) $ \logical0 ->
   gamble (jSizedLogical schema) $ \logical1 ->
   either (flip counterexample False) id $ do


### PR DESCRIPTION
This adds support for marking a table/column as being able to receive a default value if it is not present when merging two files with different schemas.

The basic use case:
```
{ "attribute1": <map time value> }
+merge+
{ "attribute2": <map time value> }
==>
{ "attribute1": <map time value>, "attribute2": <map time value> }
```

`attribute1` and `attribute2` need to be marked as being allowed to be set to a default in order for this to be legal.

! @amosr @tranma 
/jury approved @tranma @amosr