### PR TITLE
Make Haskell merge the default

### DIFF
--- a/zebra-cli/src/Zebra/Command/Export.hs
+++ b/zebra-cli/src/Zebra/Command/Export.hs
@@ -103,6 +103,8 @@ zebraExport export = do
           loop xs . hoist (firstJoin ExportIOError) . ByteStream.injectEitherT $
             ByteStream.writeFile path (ByteStream.copy tables)
 
+        -- FIXME this should not be done in this loop, causes the whole file to
+        -- FIXME be read even though we only need the schema.
         ExportSchemaStdout : xs -> do
           lift . tryEitherT ExportIOError . liftIO $
             ByteString.hPut stdout bschema

--- a/zebra-cli/src/Zebra/Command/Import.hs
+++ b/zebra-cli/src/Zebra/Command/Import.hs
@@ -17,22 +17,20 @@ import           Control.Monad.Morph (hoist, squash)
 import           Control.Monad.Trans.Resource (MonadResource, ResourceT)
 
 import qualified Data.ByteString as ByteString
-import qualified Data.Char as Char
 import qualified Data.Text as Text
 
 import           P
 
-import           System.IO (IO, FilePath, Handle)
-import           System.IO (stdout, hFlush, hIsTerminalDevice, putStr, getLine)
+import           System.IO (IO, FilePath)
 import           System.IO.Error (IOError)
 
 import           X.Control.Monad.Trans.Either (EitherT, hoistEither, firstJoin)
 
+import           Zebra.Command.Util
 import           Zebra.Serial.Binary (BinaryStripedEncodeError)
 import qualified Zebra.Serial.Binary as Binary
 import           Zebra.Serial.Text (TextSchemaDecodeError, TextStripedDecodeError)
 import qualified Zebra.Serial.Text as Text
-import           Zebra.X.ByteStream (ByteStream)
 import qualified Zebra.X.ByteStream as ByteStream
 
 
@@ -61,47 +59,13 @@ renderImportError = \case
   ImportBinaryStripedEncodeError err ->
     Binary.renderBinaryStripedEncodeError err
 
-checkStdout :: MonadIO m => m (Maybe Handle)
-checkStdout = do
-  tty <- liftIO $ hIsTerminalDevice stdout
-  if tty then do
-    liftIO $ putStr "About to write a binary file to stdout. Are you sure? [y/N] "
-    liftIO $ hFlush stdout
-    line <- fmap Char.toLower <$> liftIO getLine
-    if line == "y" then
-      pure $ Just stdout
-    else
-      pure Nothing
-  else
-    pure $ Just stdout
-
-writeFile ::
-     MonadResource m
-  => MonadCatch m
-  => Maybe FilePath
-  -> ByteStream m ()
-  -> EitherT ImportError m ()
-writeFile mpath bss = do
-  case mpath of
-    Nothing -> do
-      mhandle <- checkStdout
-      case mhandle of
-        Nothing ->
-          pure ()
-        Just handle ->
-          firstT ImportIOError $
-            ByteStream.hPut handle bss
-
-    Just path ->
-      firstT ImportIOError $
-        ByteStream.writeFile path bss
-
 zebraImport :: (MonadResource m, MonadCatch m) => Import -> EitherT ImportError m ()
 zebraImport x = do
   schema0 <- liftIO . ByteString.readFile $ importSchema x
   schema <- firstT ImportTextSchemaDecodeError . hoistEither $ Text.decodeSchema schema0
 
-  squash . writeFile (importOutput x) .
+  squash . firstJoin ImportIOError .
+      writeFileOrStdout (importOutput x) .
     hoist (firstJoin ImportBinaryStripedEncodeError) .
       Binary.encodeStriped .
     hoist (firstJoin ImportTextStripedDecodeError) .

--- a/zebra-cli/src/Zebra/Command/Merge.hs
+++ b/zebra-cli/src/Zebra/Command/Merge.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Zebra.Command.Merge (
+    Merge(..)
+  , zebraMerge
+
+  , MergeError(..)
+  , renderMergeError
+  ) where
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Morph (hoist)
+import           Control.Monad.Trans.Resource (MonadResource, ResourceT)
+
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.Text as Text
+
+import           P
+
+import           System.IO (IO, FilePath)
+import           System.IO.Error (IOError)
+
+import           X.Control.Monad.Trans.Either (EitherT, firstJoin)
+import qualified X.Data.Vector.Cons as Cons
+
+import           Zebra.Command.Util
+import           Zebra.Merge.Table (UnionTableError)
+import qualified Zebra.Merge.Table as Merge
+import           Zebra.Serial.Binary (BinaryStripedEncodeError, BinaryStripedDecodeError)
+import           Zebra.Serial.Binary (BinaryVersion(..))
+import qualified Zebra.Serial.Binary as Binary
+import qualified Zebra.Table.Striped as Striped
+import qualified Zebra.X.ByteStream as ByteStream
+import           Zebra.X.Stream (Stream, Of)
+
+
+data Merge =
+  Merge {
+      mergeInputs :: !(NonEmpty FilePath)
+    , mergeOutput :: !(Maybe FilePath)
+    , mergeVersion :: !BinaryVersion
+    } deriving (Eq, Ord, Show)
+
+data MergeError =
+    MergeIOError !IOError
+  | MergeBinaryStripedDecodeError !BinaryStripedDecodeError
+  | MergeBinaryStripedEncodeError !BinaryStripedEncodeError
+  | MergeUnionTableError !UnionTableError
+    deriving (Eq, Show)
+
+renderMergeError :: MergeError -> Text
+renderMergeError = \case
+  MergeIOError err ->
+    Text.pack (show err)
+  MergeBinaryStripedDecodeError err ->
+    Binary.renderBinaryStripedDecodeError err
+  MergeBinaryStripedEncodeError err ->
+    Binary.renderBinaryStripedEncodeError err
+  MergeUnionTableError err ->
+    Merge.renderUnionTableError err
+
+readStriped :: (MonadResource m, MonadCatch m) => FilePath -> Stream (Of Striped.Table) (EitherT MergeError m) ()
+readStriped path =
+  hoist (firstJoin MergeBinaryStripedDecodeError) .
+    Binary.decodeStriped .
+  hoist (firstT MergeIOError) $
+    ByteStream.readFile path
+
+zebraMerge :: (MonadResource m, MonadCatch m) => Merge -> EitherT MergeError m ()
+zebraMerge x =
+  let
+    inputs =
+      fmap readStriped . Cons.fromNonEmpty $ mergeInputs x
+  in
+    firstJoin MergeIOError .
+      writeFileOrStdout (mergeOutput x) .
+    hoist (firstJoin MergeBinaryStripedEncodeError) .
+      Binary.encodeStripedWith (mergeVersion x) .
+    hoist (firstJoin MergeUnionTableError) $
+      Merge.unionStriped inputs
+{-# SPECIALIZE zebraMerge :: Merge -> EitherT MergeError (ResourceT IO) () #-}

--- a/zebra-cli/src/Zebra/Command/Util.hs
+++ b/zebra-cli/src/Zebra/Command/Util.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Zebra.Command.Util (
+    getBinaryStdout
+  , writeFileOrStdout
+  ) where
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Resource (MonadResource)
+
+import qualified Data.Char as Char
+
+import           P
+
+import           System.IO (FilePath, Handle, getLine, putStr)
+import           System.IO (stdout, hIsTerminalDevice, hFlush)
+import           System.IO.Error (IOError)
+
+import           X.Control.Monad.Trans.Either (EitherT)
+
+import           Zebra.X.ByteStream (ByteStream)
+import qualified Zebra.X.ByteStream as ByteStream
+
+
+getBinaryStdout :: MonadIO m => m (Maybe Handle)
+getBinaryStdout =
+  liftIO $ do
+    tty <- hIsTerminalDevice stdout
+    if tty then do
+      putStr "About to write a binary file to stdout. Are you sure? [y/N] "
+      hFlush stdout
+      line <- fmap Char.toLower <$> getLine
+      if line == "y" then
+        pure $ Just stdout
+      else
+        pure Nothing
+    else
+      pure $ Just stdout
+
+writeFileOrStdout ::
+     MonadResource m
+  => MonadCatch m
+  => Maybe FilePath
+  -> ByteStream m ()
+  -> EitherT IOError m ()
+writeFileOrStdout mpath bss = do
+  case mpath of
+    Nothing -> do
+      mhandle <- getBinaryStdout
+      case mhandle of
+        Nothing ->
+          pure ()
+        Just handle ->
+          ByteStream.hPut handle bss
+
+    Just path ->
+      ByteStream.writeFile path bss
+{-# INLINABLE writeFileOrStdout #-}

--- a/zebra-cli/zebra-cli.cabal
+++ b/zebra-cli/zebra-cli.cabal
@@ -37,8 +37,10 @@ library
 
   exposed-modules:
                     Zebra.Command
-                    Zebra.Command.Import
                     Zebra.Command.Export
+                    Zebra.Command.Import
+                    Zebra.Command.Merge
+                    Zebra.Command.Util
 
 executable zebra
   if impl(ghc >= 8.0)


### PR DESCRIPTION
This makes the Haskell merge the default for the `zebra merge` command.

I have kept the C merge for the time being, until the Haskell one has been run in production for a little while without issue. C merge can be accessed via `zebra fast-merge`.

! @amosr @tranma

@amosr don't feel obliged to review this one, was more of a heads up, I know you're writing this week.
/jury approved @tranma