### PR TITLE
Add configurable rows-per-block limit for 'zebra merge'

### DIFF
--- a/zebra-cli/main/zebra.hs
+++ b/zebra-cli/main/zebra.hs
@@ -187,6 +187,16 @@ pMerge =
    <$> some1 pInputBinary
    <*> ((Just <$> pOutputBinary) <|> pOutputBinaryStdout <|> pure Nothing)
    <*> pOutputFormat
+   <*> pMergeRowsPerBlock
+
+pMergeRowsPerBlock :: Parser MergeRowsPerBlock
+pMergeRowsPerBlock =
+  fmap MergeRowsPerBlock .
+  Options.option Options.auto $
+    Options.value 256 <>
+    Options.long "rows-per-block" <>
+    Options.metavar "ROWS_PER_BLOCK" <>
+    Options.help "The maximum numbers of rows to include in each block. (defaults to 256)"
 
 pOutputFormat :: Parser BinaryVersion
 pOutputFormat =


### PR DESCRIPTION
This adds `--rows-per-block` and an option for `zebra merge`

Previously the Haskell merge was just putting as many entities as possible in each block, but this created quite an uneven spread and causes the icicle query runtime to skyrocket to over an hour.

! @tranma @amosr 
/jury approved @amosr @tranma