### PR TITLE
Add short -n for long --rows-per-block

### DIFF
--- a/zebra-cli/main/zebra.hs
+++ b/zebra-cli/main/zebra.hs
@@ -219,6 +219,7 @@ pMergeRowsPerBlock =
   fmap MergeRowsPerBlock .
   Options.option Options.auto $
     Options.value 256 <>
+    Options.short 'n' <>
     Options.long "rows-per-block" <>
     Options.metavar "ROWS_PER_BLOCK" <>
     Options.help "The maximum numbers of rows to include in each block. (defaults to 256)"


### PR DESCRIPTION
I use `zebra merge` by hand quite a lot, tired of typing `--rows-per-block` :)

! @tranma @amosr 
/jury approved @tranma