### PR TITLE
Generalise table merge with a monoid on values

### DIFF
--- a/zebra-cli/main/zebra.hs
+++ b/zebra-cli/main/zebra.hs
@@ -214,6 +214,23 @@ pMerge =
    <*> pOutputFormat
    <*> pMergeRowsPerBlock
    <*> optional pMergeMaximumRowSize
+   <*> pMergeMode
+
+pMergeMode :: Parser MergeMode
+pMergeMode =
+  fromMaybe MergeValue <$> optional (pMergeValue <|> pMergeMeasure)
+
+pMergeValue :: Parser MergeMode
+pMergeValue =
+  Options.flag' MergeValue $
+    Options.long "value" <>
+    Options.help "Standard merge of input values. Each key needs to fit wholly in memory."
+
+pMergeMeasure :: Parser MergeMode
+pMergeMeasure =
+  Options.flag' MergeMeasure $
+    Options.long "measure" <>
+    Options.help "Merge by measuring the size of input values."
 
 pMergeRowsPerBlock :: Parser MergeRowsPerBlock
 pMergeRowsPerBlock =

--- a/zebra-core/test/Test/Zebra/Merge/Table.hs
+++ b/zebra-core/test/Test/Zebra/Merge/Table.hs
@@ -83,7 +83,7 @@ unionList ::
    -> Cons Boxed.Vector (NonEmpty Striped.Table)
    -> Either String (Maybe Striped.Table)
 unionList msize xss0 =
-  case runIdentity . runEitherT . Stream.toList . Merge.unionStriped msize $ fmap Stream.each xss0 of
+  case runIdentity . runEitherT . Stream.toList . Merge.unionStriped Merge.valueMonoid msize $ fmap Stream.each xss0 of
     Left (UnionLogicalMergeError _) ->
       pure Nothing
     Left err ->


### PR DESCRIPTION
This is a simple change to allow substituting the standard value union with another monoid, such that `merge` can be used to calculate the number of bytes used by each key. With this information we can filter out any abnormally large entities. Example:

```
./dist/build/Zebra/zebra merge input0.zbin --measure -o sizes.zbin                                                                                                                                                                                                                                                                                        
./dist/build/Zebra/zebra export sizes.zbin
{"key":{"entity_hash":10,"entity_id":"barney"},"value":24}
{"key":{"entity_hash":10,"entity_id":"homer"},"value":24}
{"key":{"entity_hash":20,"entity_id":"marge"},"value":24}
./dist/build/Zebra/zebra merge input0.zbin -o values.zbin                                                                                                                                                                                                                                                                                        
./dist/build/Zebra/zebra export values.zbin
{"key":{"entity_hash":10,"entity_id":"barney"},"value":{"item":{"none":{}},"cash":27.6}}
{"key":{"entity_hash":10,"entity_id":"homer"},"value":{"item":{"none":{}},"cash":6.1}}
{"key":{"entity_hash":20,"entity_id":"marge"},"value":{"item":{"none":{}},"cash":45.1}}
```