### PR TITLE
Be more robust in the face of non-distinct input

### DIFF
--- a/zebra-core/src/Zebra/Table/Striped.hs
+++ b/zebra-core/src/Zebra/Table/Striped.hs
@@ -581,7 +581,7 @@ ensureSorted kvs =
 fromSorted :: Boxed.Vector (Logical.Value, Logical.Value) -> Either StripedError (Map Logical.Value Logical.Value)
 fromSorted kvs = do
   ensureSorted kvs
-  pure . Map.fromDistinctAscList $ Boxed.toList kvs
+  pure . Map.fromAscList $ Boxed.toList kvs
 {-# INLINABLE fromSorted #-}
 
 toValues :: Column -> Either StripedError (Boxed.Vector Logical.Value)


### PR DESCRIPTION
Scatters from zz seem to be outputting non-distinct output into the part
files. This broke the invariant for input being wrapped up in a map most
probably leading to the maps being invalid and unexpected, unsorted data
being written out.

! @nhibberd @HuwCampbell 