### PR TITLE
Topic/consistency check

### DIFF
--- a/zebra-cli/ambiata-zebra-cli.cabal
+++ b/zebra-cli/ambiata-zebra-cli.cabal
@@ -41,6 +41,7 @@ library
   exposed-modules:
                     Zebra.Command
                     Zebra.Command.Adapt
+                    Zebra.Command.Consistency
                     Zebra.Command.Export
                     Zebra.Command.Import
                     Zebra.Command.Merge

--- a/zebra-cli/main/zebra.hs
+++ b/zebra-cli/main/zebra.hs
@@ -24,6 +24,7 @@ import qualified X.Options.Applicative as Options
 
 import           Zebra.Command
 import           Zebra.Command.Adapt
+import           Zebra.Command.Consistency
 import           Zebra.Command.Export
 import           Zebra.Command.Import
 import           Zebra.Command.Merge
@@ -45,6 +46,7 @@ data Command =
   | ZebraExport !Export
   | ZebraMerge !Merge
   | ZebraAdapt !Adapt
+  | ZebraConsistency !Consistency
   -- FIXME cleanup: move to own module like above commands
   | ZebraCat !(NonEmpty FilePath) !CatOptions
   | ZebraFacts !FilePath
@@ -81,6 +83,10 @@ commands =
       (ZebraAdapt <$> pAdapt)
       "adapt"
       "Adapt a zebra binary file so that it uses a different, but compatible, schema."
+  , cmd
+      (ZebraConsistency <$> pConsistency)
+      "consistency"
+      "Check zebra maps are well formed and blocks have a consistent ordering."
   -- FIXME cleanup: move to own module like above commands
   , cmd
       (ZebraCat <$> some1 pInputBinary <*> pCatOptions)
@@ -148,6 +154,9 @@ pAdaptSchema =
     Options.long "schema" <>
     Options.metavar "INPUT_ZEBRA_SCHEMA" <>
     Options.help "Path to a schema file which all inputs will be adapted to before processing"
+
+pConsistency :: Parser Consistency
+pConsistency = Consistency <$> pInputBinary
 
 pOutputBinaryStdout :: Parser (Maybe FilePath)
 pOutputBinaryStdout =
@@ -324,6 +333,10 @@ run = \case
   ZebraAdapt adapt ->
     orDie renderAdaptError . hoist runResourceT $
       zebraAdapt adapt
+
+  ZebraConsistency consistency ->
+    orDie renderConsistencyError . hoist runResourceT $
+      zebraConsistency consistency
 
   -- FIXME cleanup: move to own module like above commands
 

--- a/zebra-cli/src/Zebra/Command/Consistency.hs
+++ b/zebra-cli/src/Zebra/Command/Consistency.hs
@@ -12,7 +12,7 @@ module Zebra.Command.Consistency (
   , renderConsistencyError
   ) where
 
-import           Control.Monad.Catch (MonadCatch, MonadMask)
+import           Control.Monad.Catch (MonadMask)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans.Resource (MonadResource, ResourceT)
@@ -89,7 +89,7 @@ summariseBlock = \case
         BlockRange (Just bmin) (Just bmax)
 
 zebraConsistency ::
-     (MonadResource m, MonadCatch m, MonadMask m)
+     (MonadResource m, MonadMask m)
   => Consistency
   -> EitherT ConsistencyError m ()
 zebraConsistency x =

--- a/zebra-cli/src/Zebra/Command/Consistency.hs
+++ b/zebra-cli/src/Zebra/Command/Consistency.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Zebra.Command.Consistency (
+    Consistency(..)
+
+  , zebraConsistency
+  , renderConsistencyError
+  ) where
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Morph (hoist)
+import           Control.Monad.Trans.Resource (MonadResource, ResourceT)
+
+import qualified Data.Text as Text
+import qualified Data.Map as Map
+
+import           P
+
+import           System.IO (IO, FilePath)
+import           System.IO.Error (IOError)
+
+import qualified Viking.ByteStream as ByteStream
+import qualified Viking.Stream as Stream
+
+import           X.Control.Monad.Trans.Either (EitherT, firstJoin, hoistEither)
+
+import           Zebra.Serial.Binary (BinaryStripedDecodeError)
+import qualified Zebra.Serial.Binary as Binary
+import qualified Zebra.Table.Logical as Logical
+import           Zebra.Table.Striped (StripedError)
+import qualified Zebra.Table.Striped as Striped
+
+
+data Consistency =
+  Consistency {
+      consistencyInput :: !FilePath
+    } deriving (Eq, Ord, Show)
+
+data ConsistencyError =
+    ConsistencyIOError !IOError
+  | ConsistencyStripedDecodeError !BinaryStripedDecodeError
+  | ConsistencyStripedError !StripedError
+  | ConsistencyInterBlock Int Logical.Value Logical.Value
+    deriving (Eq, Show)
+
+data BlockRange =
+  BlockRange {
+      _blockMinKey :: Maybe (Logical.Value)
+    , _blockMaxKey :: Maybe (Logical.Value)
+    } deriving (Eq, Ord, Show)
+
+renderConsistencyError :: ConsistencyError -> Text
+renderConsistencyError = \case
+  ConsistencyIOError err ->
+    Text.pack (show err)
+  ConsistencyStripedDecodeError err ->
+    "Error decoding: " <> Binary.renderBinaryStripedDecodeError err
+  ConsistencyStripedError err ->
+    Striped.renderStripedError err
+  ConsistencyInterBlock chunk keya keyb ->
+    Text.unlines [
+      "Consistency check failure:"
+    , "Chunk " <> Text.pack (show chunk) <> " has max key:"
+    , "  " <> Text.pack (show keya)
+    , "while the following chunk starts with"
+    , "  " <> Text.pack (show keyb)
+    ]
+
+summariseBlock :: Logical.Table -> BlockRange
+summariseBlock = \case
+  Logical.Binary _ -> BlockRange Nothing Nothing
+  Logical.Array _ -> BlockRange Nothing Nothing
+  Logical.Map m ->
+    if Map.null m then
+      BlockRange Nothing Nothing
+    else
+      let
+        bmin = fst $ Map.findMin m
+        bmax = fst $ Map.findMax m
+      in
+        BlockRange (Just bmin) (Just bmax)
+
+zebraConsistency :: (MonadResource m, MonadCatch m) => Consistency -> EitherT ConsistencyError m ()
+zebraConsistency x = do
+  let
+    tables =
+      hoist (firstJoin ConsistencyStripedDecodeError) .
+        Binary.decodeStriped .
+      hoist (firstT ConsistencyIOError) $
+        ByteStream.readFile (consistencyInput x)
+
+    fromStriped =
+      Stream.mapM (hoistEither . first ConsistencyStripedError . Striped.toLogical)
+
+    blockRanges =
+      Stream.map summariseBlock $ fromStriped tables
+
+    loop mseen (BlockRange mbmin mbmax) =
+      case (mseen, mbmin) of
+        ((chunk, Just seen), Just bmin) ->
+          case compare seen bmin of
+            LT -> pure (chunk + 1, mbmax)
+            _  -> hoistEither (Left $ ConsistencyInterBlock chunk seen bmin)
+        ((chunk, _), _) ->
+          pure (chunk + 1, mbmax)
+
+  _ <- Stream.foldM_ loop (pure (0, Nothing)) pure blockRanges
+  pure ()
+
+{-# SPECIALIZE zebraConsistency :: Consistency -> EitherT ConsistencyError (ResourceT IO) () #-}


### PR DESCRIPTION
This does two things.

* Makes parsing of keys and values more strict such that invalid `Data.Map` values can't be created.
* Adds a `consistency` subcommand which displays a UI just like summary, but also checks to make sure that individual maps are well formed, as well as their interchunk relationships.